### PR TITLE
Switch auth from Google OAuth to email/password

### DIFF
--- a/client/src/pages/LandingPage.tsx
+++ b/client/src/pages/LandingPage.tsx
@@ -1,16 +1,119 @@
+import { useState } from "react";
 import { Target, Beaker, FileText, LayoutDashboard, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { supabase } from "@/lib/supabase";
 import heroImage from "@/assets/images/hero-dashboard.png";
 
-function handleLogin(): void {
-  supabase.auth.signInWithOAuth({
-    provider: "google",
-    options: { redirectTo: window.location.origin },
-  });
+function AuthForm({ defaultMode = "signin" }: { defaultMode?: "signin" | "signup" }) {
+  const [mode, setMode] = useState<"signin" | "signup">(defaultMode);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [confirmationSent, setConfirmationSent] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      if (mode === "signup") {
+        const { error: signUpError } = await supabase.auth.signUp({
+          email,
+          password,
+          options: { emailRedirectTo: window.location.origin },
+        });
+        if (signUpError) {
+          setError(signUpError.message);
+        } else {
+          setConfirmationSent(true);
+        }
+      } else {
+        const { error: signInError } = await supabase.auth.signInWithPassword({
+          email,
+          password,
+        });
+        if (signInError) {
+          setError(signInError.message);
+        }
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (confirmationSent) {
+    return (
+      <div className="space-y-4 text-center" data-testid="auth-confirmation">
+        <h3 className="text-lg font-semibold">Check your email</h3>
+        <p className="text-sm text-muted-foreground">
+          We sent a confirmation link to <strong>{email}</strong>. Click it to activate your account.
+        </p>
+        <Button variant="ghost" size="sm" onClick={() => { setConfirmationSent(false); setMode("signin"); }}>
+          Back to sign in
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm" data-testid="auth-form">
+      <div className="space-y-2">
+        <Label htmlFor="email">Email</Label>
+        <Input
+          id="email"
+          type="email"
+          placeholder="you@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          data-testid="input-email"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="password">Password</Label>
+        <Input
+          id="password"
+          type="password"
+          placeholder="Enter your password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          minLength={6}
+          data-testid="input-password"
+        />
+      </div>
+      {error && (
+        <p className="text-sm text-destructive" data-testid="auth-error">{error}</p>
+      )}
+      <Button type="submit" className="w-full" disabled={loading} data-testid="button-auth-submit">
+        {loading ? "Loading..." : mode === "signin" ? "Sign in" : "Sign up"}
+      </Button>
+      <p className="text-sm text-center text-muted-foreground">
+        {mode === "signin" ? (
+          <>Don't have an account?{" "}
+            <button type="button" className="text-primary hover:underline" onClick={() => { setMode("signup"); setError(null); }} data-testid="link-toggle-auth">
+              Sign up
+            </button>
+          </>
+        ) : (
+          <>Already have an account?{" "}
+            <button type="button" className="text-primary hover:underline" onClick={() => { setMode("signin"); setError(null); }} data-testid="link-toggle-auth">
+              Sign in
+            </button>
+          </>
+        )}
+      </p>
+    </form>
+  );
 }
 
 export default function LandingPage() {
+  const [showAuth, setShowAuth] = useState<"signin" | "signup" | null>(null);
+
   return (
     <div className="min-h-screen bg-background" data-testid="landing-page">
       <nav className="fixed top-0 w-full z-50 border-b bg-background/80 backdrop-blur-md">
@@ -22,11 +125,36 @@ export default function LandingPage() {
             <span className="font-bold text-lg tracking-tight" data-testid="text-landing-app-name">AgilityAI</span>
           </div>
           <div className="flex items-center gap-3">
-            <Button variant="ghost" data-testid="button-landing-signin" onClick={handleLogin}>Sign In</Button>
-            <Button data-testid="button-landing-get-started" onClick={handleLogin}>Get Started</Button>
+            <Button variant="ghost" data-testid="button-landing-signin" onClick={() => setShowAuth("signin")}>Sign In</Button>
+            <Button data-testid="button-landing-get-started" onClick={() => setShowAuth("signup")}>Get Started</Button>
           </div>
         </div>
       </nav>
+
+      {showAuth && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm" data-testid="auth-overlay">
+          <div className="bg-background border rounded-xl shadow-lg p-8 w-full max-w-md mx-4 relative">
+            <button
+              className="absolute top-4 right-4 text-muted-foreground hover:text-foreground"
+              onClick={() => setShowAuth(null)}
+              data-testid="button-close-auth"
+            >
+              &times;
+            </button>
+            <div className="flex flex-col items-center gap-4 mb-6">
+              <div className="w-10 h-10 bg-primary rounded-md flex items-center justify-center text-primary-foreground font-bold">
+                A
+              </div>
+              <h2 className="text-xl font-semibold">
+                {showAuth === "signin" ? "Welcome back" : "Create your account"}
+              </h2>
+            </div>
+            <div className="flex justify-center">
+              <AuthForm defaultMode={showAuth} />
+            </div>
+          </div>
+        </div>
+      )}
 
       <main className="pt-16">
         <section className="max-w-6xl mx-auto px-6 py-24 md:py-32">
@@ -40,7 +168,7 @@ export default function LandingPage() {
                 decision-ready deliverables — all in one workspace with AI assistance.
               </p>
               <div className="flex flex-col sm:flex-row gap-3 pt-2">
-                <Button size="lg" className="gap-2 text-base px-6" data-testid="button-landing-cta" onClick={handleLogin}>
+                <Button size="lg" className="gap-2 text-base px-6" data-testid="button-landing-cta" onClick={() => setShowAuth("signup")}>
                     Get Started <ArrowRight className="w-4 h-4" />
                   </Button>
               </div>
@@ -108,7 +236,7 @@ export default function LandingPage() {
             <p className="text-muted-foreground">
               Sign up in seconds and start organizing your project today.
             </p>
-            <Button size="lg" className="gap-2 text-base px-8 mt-2" data-testid="button-landing-bottom-cta" onClick={handleLogin}>
+            <Button size="lg" className="gap-2 text-base px-8 mt-2" data-testid="button-landing-bottom-cta" onClick={() => setShowAuth("signup")}>
                 Get Started Free <ArrowRight className="w-4 h-4" />
               </Button>
           </div>


### PR DESCRIPTION
## Summary
- Replace Google OAuth (`signInWithOAuth`) with Supabase email/password auth (`signInWithPassword` + `signUp`)
- Add modal-based auth form with sign-in/sign-up toggle
- Show email confirmation message after sign-up
- All landing page buttons (Sign In, Get Started, CTAs) open the auth modal

## Test plan
- [ ] Sign up with email/password creates account
- [ ] Confirmation email is sent after sign-up
- [ ] Sign in with valid credentials works
- [ ] Invalid credentials show error message
- [ ] `npm run check` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)