### PR TITLE
feat: wire up AI agent into chat experience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,8 @@ DATABASE_URL=postgresql://postgres:password@db.your-project.supabase.co:5432/pos
 SUPABASE_URL=https://your-project.supabase.co
 CORS_ORIGIN=https://your-vercel-app.vercel.app
 PORT=3001
+
+# === AI Provider ===
+AI_PROVIDER=anthropic
+ANTHROPIC_API_KEY=sk-ant-...
+# OPENAI_API_KEY=sk-...

--- a/client/src/components/shared/ChatWorkspace.tsx
+++ b/client/src/components/shared/ChatWorkspace.tsx
@@ -24,16 +24,17 @@ interface ChatWorkspaceProps {
   onSendMessage: (content: string) => void;
   onSaveContent?: (messageId: string, destinationId: string) => void;
   saveDestinations?: { id: string; label: string }[];
+  isStreaming?: boolean;
   className?: string;
 }
 
-export function ChatWorkspace({ messages, onSendMessage, onSaveContent, saveDestinations, className }: ChatWorkspaceProps) {
+export function ChatWorkspace({ messages, onSendMessage, onSaveContent, saveDestinations, isStreaming, className }: ChatWorkspaceProps) {
   const [input, setInput] = useState("");
   const [saveOpenFor, setSaveOpenFor] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const handleSend = () => {
-    if (!input.trim()) return;
+    if (!input.trim() || isStreaming) return;
     onSendMessage(input);
     setInput("");
   };
@@ -81,7 +82,7 @@ export function ChatWorkspace({ messages, onSendMessage, onSaveContent, saveDest
               <div className="flex-1 min-w-0">
                  <div className="flex items-start justify-between gap-4">
                      <div className="text-foreground leading-snug whitespace-pre-wrap">
-                        {msg.content}
+                        {msg.content}{msg.isStreaming && <span className="inline-block w-1.5 h-4 bg-primary/70 animate-pulse ml-0.5 align-text-bottom rounded-sm" />}
                      </div>
                      
                      {/* Metadata & Actions - Inline Right */}
@@ -155,7 +156,8 @@ export function ChatWorkspace({ messages, onSendMessage, onSaveContent, saveDest
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Type a message..."
+            placeholder={isStreaming ? "Waiting for response..." : "Type a message..."}
+            disabled={isStreaming}
             className="min-h-[36px] max-h-[120px] resize-none pr-9 py-2 bg-background border-input focus-visible:ring-1 focus-visible:ring-primary shadow-sm rounded-sm text-sm leading-tight"
           />
           <div className="absolute right-1.5 bottom-1">
@@ -164,7 +166,7 @@ export function ChatWorkspace({ messages, onSendMessage, onSaveContent, saveDest
                variant="ghost"
                className={cn("h-6 w-6 transition-all rounded-sm", input.trim() ? "text-primary hover:text-primary hover:bg-primary/10" : "text-muted-foreground")}
                onClick={handleSend}
-               disabled={!input.trim()}
+               disabled={!input.trim() || isStreaming}
              >
                <ArrowUp className="w-3.5 h-3.5" />
              </Button>

--- a/client/src/hooks/use-chat-stream.ts
+++ b/client/src/hooks/use-chat-stream.ts
@@ -1,0 +1,136 @@
+import { useState, useCallback, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { getAuthHeaders } from "@/lib/queryClient";
+import { API_BASE_URL } from "@/lib/config";
+import type { Message } from "@/lib/types";
+
+type UseChatStreamOptions = {
+  parentId: string;
+  parentType: string;
+  onMessageComplete?: () => void;
+};
+
+type UseChatStreamReturn = {
+  streamingMessage: Message | null;
+  isStreaming: boolean;
+  sendMessage: (content: string) => void;
+};
+
+export function useChatStream({
+  parentId,
+  parentType,
+  onMessageComplete,
+}: UseChatStreamOptions): UseChatStreamReturn {
+  const queryClient = useQueryClient();
+  const [streamingMessage, setStreamingMessage] = useState<Message | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const sendMessage = useCallback(
+    async (content: string) => {
+      if (isStreaming || !parentId) return;
+
+      setIsStreaming(true);
+
+      const streamId = `stream-${Date.now()}`;
+      setStreamingMessage({
+        id: streamId,
+        role: "ai",
+        content: "",
+        timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+        isStreaming: true,
+      });
+
+      try {
+        const headers = await getAuthHeaders();
+        const controller = new AbortController();
+        abortRef.current = controller;
+
+        const response = await fetch(`${API_BASE_URL}/api/chat`, {
+          method: "POST",
+          headers: {
+            ...headers,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ parentId, parentType, content }),
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Chat request failed: ${response.status}`);
+        }
+
+        const reader = response.body?.getReader();
+        if (!reader) throw new Error("No response body");
+
+        const decoder = new TextDecoder();
+        let accumulated = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          const chunk = decoder.decode(value, { stream: true });
+          const lines = chunk.split("\n");
+
+          for (const line of lines) {
+            if (!line.startsWith("data: ")) continue;
+            const jsonStr = line.slice(6).trim();
+            if (!jsonStr) continue;
+
+            try {
+              const event = JSON.parse(jsonStr) as
+                | { type: "token"; text: string }
+                | { type: "done"; userMessageId: string; aiMessageId: string }
+                | { type: "error"; message: string };
+
+              if (event.type === "token") {
+                accumulated += event.text;
+                setStreamingMessage({
+                  id: streamId,
+                  role: "ai",
+                  content: accumulated,
+                  timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+                  isStreaming: true,
+                });
+              } else if (event.type === "done") {
+                setStreamingMessage(null);
+                setIsStreaming(false);
+                queryClient.invalidateQueries({
+                  queryKey: ["/api/messages", parentType, parentId],
+                });
+                onMessageComplete?.();
+              } else if (event.type === "error") {
+                setStreamingMessage({
+                  id: streamId,
+                  role: "ai",
+                  content: `Sorry, I encountered an error: ${event.message}`,
+                  timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+                  isStreaming: false,
+                });
+                setIsStreaming(false);
+              }
+            } catch {
+              // skip malformed JSON lines
+            }
+          }
+        }
+      } catch (err) {
+        if ((err as Error).name === "AbortError") return;
+        setStreamingMessage({
+          id: `error-${Date.now()}`,
+          role: "ai",
+          content: "Sorry, something went wrong. Please try again.",
+          timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+          isStreaming: false,
+        });
+      } finally {
+        setIsStreaming(false);
+        abortRef.current = null;
+      }
+    },
+    [isStreaming, parentId, parentType, queryClient, onMessageComplete]
+  );
+
+  return { streamingMessage, isStreaming, sendMessage };
+}

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -7,6 +7,7 @@ export type Message = {
   timestamp: string;
   hasSaveableContent?: boolean; // For the [Paperclip] push mechanic
   saved?: boolean;
+  isStreaming?: boolean;
 };
 
 export type Section = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.78.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -95,6 +96,26 @@
       },
       "optionalDependencies": {
         "bufferutil": "^4.0.8"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
+      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5566,6 +5587,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -7007,6 +7041,12 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "constitution": "bash script/sync-governance.sh"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.78.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/script/build.ts
+++ b/script/build.ts
@@ -4,6 +4,7 @@ import { rm, readFile } from "fs/promises";
 // server deps to bundle to reduce openat(2) syscalls
 // which helps cold start times
 const allowlist = [
+  "@anthropic-ai/sdk",
   "@google/generative-ai",
   "@supabase/supabase-js",
   "axios",

--- a/server/ai/anthropic.ts
+++ b/server/ai/anthropic.ts
@@ -1,0 +1,40 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { AIProvider, AIMessage } from "./types";
+
+export class AnthropicProvider implements AIProvider {
+  private client: Anthropic;
+
+  constructor() {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      throw new Error("ANTHROPIC_API_KEY environment variable is required");
+    }
+    this.client = new Anthropic({ apiKey });
+  }
+
+  async *streamCompletion(messages: AIMessage[]): AsyncIterable<string> {
+    const systemMessage = messages.find((m) => m.role === "system");
+    const conversationMessages = messages
+      .filter((m) => m.role !== "system")
+      .map((m) => ({
+        role: m.role as "user" | "assistant",
+        content: m.content,
+      }));
+
+    const stream = this.client.messages.stream({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 4096,
+      system: systemMessage?.content || "",
+      messages: conversationMessages,
+    });
+
+    for await (const event of stream) {
+      if (
+        event.type === "content_block_delta" &&
+        event.delta.type === "text_delta"
+      ) {
+        yield event.delta.text;
+      }
+    }
+  }
+}

--- a/server/ai/index.ts
+++ b/server/ai/index.ts
@@ -1,0 +1,28 @@
+import type { AIProvider } from "./types";
+
+let cachedProvider: AIProvider | null = null;
+
+export function getAIProvider(): AIProvider {
+  if (cachedProvider) return cachedProvider;
+
+  const providerName = (process.env.AI_PROVIDER || "anthropic").toLowerCase();
+
+  switch (providerName) {
+    case "anthropic": {
+      const { AnthropicProvider } = require("./anthropic") as typeof import("./anthropic");
+      cachedProvider = new AnthropicProvider();
+      break;
+    }
+    case "openai": {
+      const { OpenAIProvider } = require("./openai") as typeof import("./openai");
+      cachedProvider = new OpenAIProvider();
+      break;
+    }
+    default:
+      throw new Error(`Unknown AI_PROVIDER: ${providerName}. Use "anthropic" or "openai".`);
+  }
+
+  return cachedProvider;
+}
+
+export type { AIMessage, AIProvider, ChatRequest } from "./types";

--- a/server/ai/openai.ts
+++ b/server/ai/openai.ts
@@ -1,0 +1,32 @@
+import OpenAI from "openai";
+import type { AIProvider, AIMessage } from "./types";
+
+export class OpenAIProvider implements AIProvider {
+  private client: OpenAI;
+
+  constructor() {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error("OPENAI_API_KEY environment variable is required");
+    }
+    this.client = new OpenAI({ apiKey });
+  }
+
+  async *streamCompletion(messages: AIMessage[]): AsyncIterable<string> {
+    const stream = await this.client.chat.completions.create({
+      model: "gpt-4o",
+      messages: messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+      })),
+      stream: true,
+    });
+
+    for await (const chunk of stream) {
+      const text = chunk.choices[0]?.delta?.content;
+      if (text) {
+        yield text;
+      }
+    }
+  }
+}

--- a/server/ai/types.ts
+++ b/server/ai/types.ts
@@ -1,0 +1,14 @@
+export type AIMessage = {
+  role: "system" | "user" | "assistant";
+  content: string;
+};
+
+export interface AIProvider {
+  streamCompletion(messages: AIMessage[]): AsyncIterable<string>;
+}
+
+export type ChatRequest = {
+  parentId: string;
+  parentType: string;
+  content: string;
+};


### PR DESCRIPTION
## Summary
- Add provider-agnostic AI service (Anthropic default, OpenAI swap-in) with SSE streaming
- Replace all hardcoded placeholder AI responses across 4 pages (Dashboard, Goals, Lab, Deliverables) with real streaming AI responses
- Server handles message persistence, conversation history, and system prompt injection from core_queries

## Environment Variables (Railway)
| Variable | Required | Description |
|----------|----------|-------------|
| `AI_PROVIDER` | No | `anthropic` (default) or `openai` |
| `ANTHROPIC_API_KEY` | Yes (if anthropic) | Anthropic API key |
| `OPENAI_API_KEY` | Yes (if openai) | OpenAI API key |

## Test plan
- [ ] Set `ANTHROPIC_API_KEY` in Railway environment variables
- [ ] Send a message in Dashboard chat — verify streaming AI response appears token-by-token
- [ ] Send a message in Goals bucket chat — verify response with correct context
- [ ] Send a message in Lab and Deliverables chats — verify streaming works
- [ ] Verify messages are persisted to DB after stream completes
- [ ] Verify send button is disabled during streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)