### PR TITLE
fix: install openai SDK to resolve build failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "jose": "^6.1.3",
         "lucide-react": "^0.545.0",
         "next-themes": "^0.4.6",
+        "openai": "^6.22.0",
         "pg": "^8.16.3",
         "react": "^19.2.0",
         "react-day-picker": "^9.11.1",
@@ -6100,6 +6101,27 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.22.0.tgz",
+      "integrity": "sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/parseurl": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "jose": "^6.1.3",
     "lucide-react": "^0.545.0",
     "next-themes": "^0.4.6",
+    "openai": "^6.22.0",
     "pg": "^8.16.3",
     "react": "^19.2.0",
     "react-day-picker": "^9.11.1",


### PR DESCRIPTION
## Summary
- Install `openai` package which was in the esbuild bundle allowlist but missing from dependencies, causing Railway build to fail

## Test plan
- [ ] Railway build succeeds
- [ ] Chat streaming works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)