### PR TITLE
fix: use static imports for AI providers to fix bundled build

### DIFF
--- a/server/ai/index.ts
+++ b/server/ai/index.ts
@@ -1,4 +1,6 @@
 import type { AIProvider } from "./types";
+import { AnthropicProvider } from "./anthropic";
+import { OpenAIProvider } from "./openai";
 
 let cachedProvider: AIProvider | null = null;
 
@@ -8,16 +10,12 @@ export function getAIProvider(): AIProvider {
   const providerName = (process.env.AI_PROVIDER || "anthropic").toLowerCase();
 
   switch (providerName) {
-    case "anthropic": {
-      const { AnthropicProvider } = require("./anthropic") as typeof import("./anthropic");
+    case "anthropic":
       cachedProvider = new AnthropicProvider();
       break;
-    }
-    case "openai": {
-      const { OpenAIProvider } = require("./openai") as typeof import("./openai");
+    case "openai":
       cachedProvider = new OpenAIProvider();
       break;
-    }
     default:
       throw new Error(`Unknown AI_PROVIDER: ${providerName}. Use "anthropic" or "openai".`);
   }


### PR DESCRIPTION
## Summary
- Replace dynamic `require()` with static `import` in `server/ai/index.ts`
- The `require()` calls couldn't resolve relative paths inside the esbuild-bundled CJS output, causing the AI chat endpoint to fail at runtime

## Test plan
- [ ] Railway build succeeds
- [ ] Chat streaming works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)