### PR TITLE
fix: correct parentType values in project template creation

### DIFF
--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -166,7 +166,7 @@ export function Header() {
           for (const item of items) {
             await api.items.create({
               parentId: createdBucket.id,
-              parentType: "lab",
+              parentType: "labBucket",
               ...item,
             });
           }
@@ -184,7 +184,7 @@ export function Header() {
           }
         }
 
-        const pageTypes = ["dashboard", "goals", "lab", "deliverables"];
+        const pageTypes = ["dashboard_page", "goal_page", "lab_page", "deliverable_page"];
         for (const pageType of pageTypes) {
           await api.messages.create({
             parentId: project.id,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -237,9 +237,13 @@ export class DatabaseStorage implements IStorage {
   async getProjectIdForParent(parentId: string, parentType: string): Promise<string | undefined> {
     switch (parentType) {
       case "dashboard":
+      case "dashboard_page":
       case "goals":
+      case "goal_page":
       case "lab":
-      case "deliverables": {
+      case "lab_page":
+      case "deliverables":
+      case "deliverable_page": {
         const project = await this.getProject(parentId);
         return project?.id;
       }


### PR DESCRIPTION
## Summary
- Fixed `parentType: "lab"` → `"labBucket"` for lab bucket items in `Header.tsx`, which caused the server ownership check to fail (404) and prevented `onSuccess` from firing — the root cause of projects not saving on first try
- Fixed welcome chat message `parentType` values from `"dashboard"`, `"goals"`, `"lab"`, `"deliverables"` → `"dashboard_page"`, `"goal_page"`, `"lab_page"`, `"deliverable_page"` to match what page components query with
- Added `_page` suffixed variants to `getProjectIdForParent()` in `storage.ts` so the ownership check recognizes them

## Test plan
- [ ] Create a new project with a summary — should save and appear immediately
- [ ] Verify welcome messages appear in Dashboard, Goals, Lab, and Deliverables chat panels
- [ ] Create a new project without a summary — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)