### PR TITLE
fix: project creation 405 — auto-prepend https:// to API URL

### DIFF
--- a/client/src/components/ThemeProvider.tsx
+++ b/client/src/components/ThemeProvider.tsx
@@ -8,7 +8,7 @@ export function ThemeProvider({ children }: ThemeProviderProps): React.ReactElem
     return (
         <NextThemesProvider
             attribute="class"
-            defaultTheme="dark"
+            defaultTheme="light"
             enableSystem={false}
             disableTransitionOnChange
         >

--- a/client/src/lib/config.ts
+++ b/client/src/lib/config.ts
@@ -1,1 +1,7 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "";
+function normalizeApiUrl(raw: string): string {
+    if (!raw) return "";
+    if (raw.startsWith("http://") || raw.startsWith("https://")) return raw;
+    return `https://${raw}`;
+}
+
+export const API_BASE_URL = normalizeApiUrl(import.meta.env.VITE_API_BASE_URL || "");


### PR DESCRIPTION
## Root Cause

`VITE_API_BASE_URL` on Vercel was set to `aiagility-production.up.railway.app` **without** the `https://` protocol. This caused the browser to treat it as a relative path, sending API requests to `app-ten-snowy.vercel.app/aiagility-production.up.railway.app/api/projects` → **405 Method Not Allowed**.

## Fix

Added `normalizeApiUrl()` in `config.ts` that auto-prepends `https://` when the protocol prefix is missing. This prevents silent failures even if the env var is misconfigured.

Also switches default theme to light mode per user request.

## Verification
- `npm run check` — zero TS errors
- Reproduced 405 error in browser subagent before fix