### PR TITLE
fix: support multiple CORS origins

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -14,9 +14,12 @@ declare module "http" {
 
 app.use(
   cors({
-    origin: process.env.CORS_ORIGIN || (process.env.NODE_ENV === "production"
-      ? (() => { throw new Error("CORS_ORIGIN must be set in production"); })()
-      : true),
+    origin: process.env.CORS_ORIGIN
+      ? process.env.CORS_ORIGIN.split(",").map((o) => o.trim())
+      : (process.env.NODE_ENV === "production"
+        ? (() => { throw new Error("CORS_ORIGIN must be set in production"); })()
+        : true),
+    credentials: true,
   }),
 );
 


### PR DESCRIPTION
## Summary
- CORS_ORIGIN now supports comma-separated origins (e.g. `https://www.getaiagility.com,https://app-ten-snowy.vercel.app`)
- Fixes all API requests being blocked when accessing the site from the custom domain `www.getaiagility.com`
- Adds `credentials: true` to CORS config

## Root Cause
Railway's `CORS_ORIGIN` was set to `https://app-ten-snowy.vercel.app` but the site is accessed from `https://www.getaiagility.com`. The old config only accepted a single origin string, so all requests from the custom domain failed CORS preflight.

## After Merge
Update `CORS_ORIGIN` in Railway to:
```
https://www.getaiagility.com,https://app-ten-snowy.vercel.app
```

## Test plan
- [ ] Merge and deploy to Railway
- [ ] Update CORS_ORIGIN env var in Railway to include both origins
- [ ] Verify site loads and API requests succeed from www.getaiagility.com
- [ ] Verify project creation works
- [ ] Verify AI chat streaming works

🤖 Generated with [Claude Code](https://claude.com/claude-code)