### PR TITLE
feat: upgrade OpenAI model to GPT-5.2

### DIFF
--- a/server/ai/openai.ts
+++ b/server/ai/openai.ts
@@ -14,7 +14,7 @@ export class OpenAIProvider implements AIProvider {
 
   async *streamCompletion(messages: AIMessage[]): AsyncIterable<string> {
     const stream = await this.client.chat.completions.create({
-      model: "gpt-4o",
+      model: "gpt-5.2",
       messages: messages.map((m) => ({
         role: m.role,
         content: m.content,


### PR DESCRIPTION
## Summary
- Upgrades OpenAI model from `gpt-4o` to `gpt-5.2`

## After Merge
- Set `AI_PROVIDER=openai` in Railway to switch from Anthropic (which hit usage limits) to OpenAI

🤖 Generated with [Claude Code](https://claude.com/claude-code)