### PR TITLE
feat: implement password recovery flow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,7 @@ import AdminPage from "@/pages/AdminPage";
 import CoreQsPage from "@/pages/CoreQsPage";
 import StyleGuidePage from "@/pages/StyleGuidePage";
 import NotFound from "@/pages/not-found";
+import ResetPasswordPage from "@/pages/ResetPasswordPage";
 import { Loader2 } from "lucide-react";
 
 function AuthenticatedRouter() {
@@ -31,6 +32,7 @@ function AuthenticatedRouter() {
       <Route path="/dashboard" component={DashboardPage} />
       <Route path="/lab" component={LabPage} />
       <Route path="/deliverables" component={DeliverablesPage} />
+      <Route path="/reset-password" component={ResetPasswordPage} />
 
       <Route path="/settings/preferences" component={PreferencesPage} />
       <Route path="/settings/notifications" component={NotificationsPage} />
@@ -63,7 +65,12 @@ function AppContent() {
   }
 
   if (!isAuthenticated) {
-    return <LandingPage />;
+    return (
+      <Switch>
+        <Route path="/reset-password" component={ResetPasswordPage} />
+        <Route component={LandingPage} />
+      </Switch>
+    );
   }
 
   return <AuthenticatedRouter />;

--- a/client/src/pages/LandingPage.tsx
+++ b/client/src/pages/LandingPage.tsx
@@ -6,13 +6,14 @@ import { Label } from "@/components/ui/label";
 import { supabase } from "@/lib/supabase";
 import heroImage from "@/assets/images/hero-dashboard.png";
 
-function AuthForm({ defaultMode = "signin" }: { defaultMode?: "signin" | "signup" }) {
-  const [mode, setMode] = useState<"signin" | "signup">(defaultMode);
+function AuthForm({ defaultMode = "signin" }: { defaultMode?: "signin" | "signup" | "forgot-password" }) {
+  const [mode, setMode] = useState<"signin" | "signup" | "forgot-password">(defaultMode);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [confirmationSent, setConfirmationSent] = useState(false);
+  const [recoverySent, setRecoverySent] = useState(false);
 
   async function handleSubmit(e: React.FormEvent): Promise<void> {
     e.preventDefault();
@@ -30,6 +31,15 @@ function AuthForm({ defaultMode = "signin" }: { defaultMode?: "signin" | "signup
           setError(signUpError.message);
         } else {
           setConfirmationSent(true);
+        }
+      } else if (mode === "forgot-password") {
+        const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
+          redirectTo: `${window.location.origin}/reset-password`,
+        });
+        if (resetError) {
+          setError(resetError.message);
+        } else {
+          setRecoverySent(true);
         }
       } else {
         const { error: signInError } = await supabase.auth.signInWithPassword({
@@ -59,6 +69,20 @@ function AuthForm({ defaultMode = "signin" }: { defaultMode?: "signin" | "signup
     );
   }
 
+  if (recoverySent) {
+    return (
+      <div className="space-y-4 text-center" data-testid="auth-recovery">
+        <h3 className="text-lg font-semibold">Check your email</h3>
+        <p className="text-sm text-muted-foreground">
+          We sent a password reset link to <strong>{email}</strong>.
+        </p>
+        <Button variant="ghost" size="sm" onClick={() => { setRecoverySent(false); setMode("signin"); }}>
+          Back to sign in
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm" data-testid="auth-form">
       <div className="space-y-2">
@@ -73,24 +97,37 @@ function AuthForm({ defaultMode = "signin" }: { defaultMode?: "signin" | "signup
           data-testid="input-email"
         />
       </div>
-      <div className="space-y-2">
-        <Label htmlFor="password">Password</Label>
-        <Input
-          id="password"
-          type="password"
-          placeholder="Enter your password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-          minLength={6}
-          data-testid="input-password"
-        />
-      </div>
+      {mode !== "forgot-password" && (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="password">Password</Label>
+            {mode === "signin" && (
+              <button
+                type="button"
+                className="text-xs text-primary hover:underline"
+                onClick={() => { setMode("forgot-password"); setError(null); }}
+              >
+                Forgot password?
+              </button>
+            )}
+          </div>
+          <Input
+            id="password"
+            type="password"
+            placeholder="Enter your password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={6}
+            data-testid="input-password"
+          />
+        </div>
+      )}
       {error && (
         <p className="text-sm text-destructive" data-testid="auth-error">{error}</p>
       )}
       <Button type="submit" className="w-full" disabled={loading} data-testid="button-auth-submit">
-        {loading ? "Loading..." : mode === "signin" ? "Sign in" : "Sign up"}
+        {loading ? "Loading..." : mode === "signin" ? "Sign in" : mode === "signup" ? "Sign up" : "Send reset link"}
       </Button>
       <p className="text-sm text-center text-muted-foreground">
         {mode === "signin" ? (
@@ -99,12 +136,16 @@ function AuthForm({ defaultMode = "signin" }: { defaultMode?: "signin" | "signup
               Sign up
             </button>
           </>
-        ) : (
+        ) : mode === "signup" ? (
           <>Already have an account?{" "}
             <button type="button" className="text-primary hover:underline" onClick={() => { setMode("signin"); setError(null); }} data-testid="link-toggle-auth">
               Sign in
             </button>
           </>
+        ) : (
+          <button type="button" className="text-primary hover:underline" onClick={() => { setMode("signin"); setError(null); }}>
+            Back to sign in
+          </button>
         )}
       </p>
     </form>
@@ -169,8 +210,8 @@ export default function LandingPage() {
               </p>
               <div className="flex flex-col sm:flex-row gap-3 pt-2">
                 <Button size="lg" className="gap-2 text-base px-6" data-testid="button-landing-cta" onClick={() => setShowAuth("signup")}>
-                    Get Started <ArrowRight className="w-4 h-4" />
-                  </Button>
+                  Get Started <ArrowRight className="w-4 h-4" />
+                </Button>
               </div>
               <div className="flex items-center gap-4 pt-2">
                 <span className="text-sm text-muted-foreground" data-testid="text-landing-trust-1">Free to use</span>
@@ -237,8 +278,8 @@ export default function LandingPage() {
               Sign up in seconds and start organizing your project today.
             </p>
             <Button size="lg" className="gap-2 text-base px-8 mt-2" data-testid="button-landing-bottom-cta" onClick={() => setShowAuth("signup")}>
-                Get Started Free <ArrowRight className="w-4 h-4" />
-              </Button>
+              Get Started Free <ArrowRight className="w-4 h-4" />
+            </Button>
           </div>
         </section>
       </main>

--- a/client/src/pages/ResetPasswordPage.tsx
+++ b/client/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { useLocation } from "wouter";
+import { supabase } from "@/lib/supabase";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export default function ResetPasswordPage() {
+    const [, setLocation] = useLocation();
+    const [password, setPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [success, setSuccess] = useState(false);
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        setError(null);
+
+        if (password !== confirmPassword) {
+            setError("Passwords do not match");
+            return;
+        }
+
+        setLoading(true);
+        try {
+            const { error: updateError } = await supabase.auth.updateUser({
+                password: password
+            });
+
+            if (updateError) {
+                setError(updateError.message);
+            } else {
+                setSuccess(true);
+                setTimeout(() => setLocation("/dashboard"), 3000);
+            }
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    if (success) {
+        return (
+            <div className="min-h-screen bg-background flex flex-col items-center justify-center p-4">
+                <div className="bg-background border rounded-xl shadow-sm p-8 max-w-md w-full text-center space-y-4">
+                    <h2 className="text-xl font-semibold text-primary">Password updated!</h2>
+                    <p className="text-sm text-muted-foreground">
+                        Your password has been successfully reset. Redirecting you to the dashboard...
+                    </p>
+                    <Button className="w-full mt-4" onClick={() => setLocation("/dashboard")}>
+                        Go to Dashboard Now
+                    </Button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-screen bg-background flex flex-col items-center justify-center p-4">
+            <div className="bg-background border rounded-xl shadow-sm p-8 max-w-md w-full">
+                <div className="flex flex-col items-center gap-4 mb-6">
+                    <div className="w-10 h-10 bg-primary rounded-md flex items-center justify-center text-primary-foreground font-bold">
+                        A
+                    </div>
+                    <h2 className="text-xl font-semibold">Reset Your Password</h2>
+                    <p className="text-sm text-muted-foreground text-center">
+                        Enter a new password for your account.
+                    </p>
+                </div>
+
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="new-password">New Password</Label>
+                        <Input
+                            id="new-password"
+                            type="password"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            required
+                            minLength={6}
+                            placeholder="Enter new password"
+                        />
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="confirm-password">Confirm Password</Label>
+                        <Input
+                            id="confirm-password"
+                            type="password"
+                            value={confirmPassword}
+                            onChange={(e) => setConfirmPassword(e.target.value)}
+                            required
+                            minLength={6}
+                            placeholder="Confirm new password"
+                        />
+                    </div>
+
+                    {error && (
+                        <p className="text-sm text-destructive font-medium">{error}</p>
+                    )}
+
+                    <Button type="submit" className="w-full" disabled={loading}>
+                        {loading ? "Updating..." : "Update Password"}
+                    </Button>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/script/sync-governance.sh
+++ b/script/sync-governance.sh
@@ -89,13 +89,15 @@ fi
 TEMPLATE_CONTENT=$(cat "$TEMPLATE")
 
 # IDE config: target_path and placeholder replacement value
-declare -A IDE_TARGETS
-IDE_TARGETS["$HOME/.claude/CLAUDE.md"]="CLAUDE.md"
-IDE_TARGETS["$HOME/.codex/AGENTS.md"]="AGENTS.md"
-IDE_TARGETS["$HOME/.gemini/GEMINI.md"]="GEMINI.md"
+IDE_TARGETS=(
+  "$HOME/.claude/CLAUDE.md:CLAUDE.md"
+  "$HOME/.codex/AGENTS.md:AGENTS.md"
+  "$HOME/.gemini/GEMINI.md:GEMINI.md"
+)
 
-for target_path in "${!IDE_TARGETS[@]}"; do
-  ide_file="${IDE_TARGETS[$target_path]}"
+for target in "${IDE_TARGETS[@]}"; do
+  target_path="${target%%:*}"
+  ide_file="${target##*:}"
   target_dir="$(dirname "$target_path")"
 
   # Create directory if it doesn't exist


### PR DESCRIPTION
## Changes
- Added 'Forgot password?' link to the sign-in form on the Landing Page
- Integrated Supabase `resetPasswordForEmail` to send recovery emails
- Created a new `ResetPasswordPage` at `/reset-password` for users to set a new password after clicking the email link
- Registered the route in `App.tsx` for both authenticated and unauthenticated states
- Fixed macOS bash compatibility issue in `sync-governance.sh` (replaced `declare -A` with portable array syntax)