### PR TITLE
fix: redirect to /reset-password on PASSWORD_RECOVERY event

### DIFF
--- a/client/src/hooks/use-auth.ts
+++ b/client/src/hooks/use-auth.ts
@@ -78,6 +78,10 @@ export function useAuth() {
       async (event, newSession) => {
         setSession(newSession);
 
+        if (event === "PASSWORD_RECOVERY") {
+          window.location.href = "/reset-password";
+          return;
+        }
         if (event === "SIGNED_IN") {
           await syncUser();
           queryClient.invalidateQueries({ queryKey: ["/api/auth/user"] });


### PR DESCRIPTION
## Problem
Clicking the Supabase password recovery email link redirects to `/#` instead of `/reset-password`. This is because Supabase sends recovery tokens as hash fragments to the Site URL, not to the `redirectTo` parameter.

## Fix
Added `PASSWORD_RECOVERY` event detection in `use-auth.ts` `onAuthStateChange` listener. When the Supabase SDK processes the recovery hash and fires this event, the app now programmatically navigates to `/reset-password`.