### PR TITLE
fix: preserve session during password recovery

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -55,6 +55,7 @@ function AuthenticatedRouter() {
 
 function AppContent() {
   const { isLoading, isAuthenticated } = useAuth();
+  const isPasswordRecovery = sessionStorage.getItem("passwordRecovery") === "true";
 
   if (isLoading) {
     return (
@@ -71,6 +72,10 @@ function AppContent() {
         <Route component={LandingPage} />
       </Switch>
     );
+  }
+
+  if (isPasswordRecovery) {
+    return <ResetPasswordPage />;
   }
 
   return <AuthenticatedRouter />;

--- a/client/src/hooks/use-auth.ts
+++ b/client/src/hooks/use-auth.ts
@@ -79,8 +79,7 @@ export function useAuth() {
         setSession(newSession);
 
         if (event === "PASSWORD_RECOVERY") {
-          window.location.href = "/reset-password";
-          return;
+          sessionStorage.setItem("passwordRecovery", "true");
         }
         if (event === "SIGNED_IN") {
           await syncUser();

--- a/client/src/pages/ResetPasswordPage.tsx
+++ b/client/src/pages/ResetPasswordPage.tsx
@@ -31,6 +31,7 @@ export default function ResetPasswordPage() {
             if (updateError) {
                 setError(updateError.message);
             } else {
+                sessionStorage.removeItem("passwordRecovery");
                 setSuccess(true);
                 setTimeout(() => setLocation("/dashboard"), 3000);
             }


### PR DESCRIPTION
## Problem
After clicking 'Update Password' on the reset password page, the page gets stuck. The previous fix used `window.location.href` to redirect on PASSWORD_RECOVERY, which caused a full page reload that destroyed the Supabase session before it was persisted.

## Fix
- Replaced the hard redirect with a `sessionStorage` flag (`passwordRecovery`)
- `App.tsx` checks this flag and renders `ResetPasswordPage` directly when set, preserving the active Supabase session
- `ResetPasswordPage` clears the flag after a successful password update, allowing normal routing to resume