### PR TITLE
fix: handle signOut errors gracefully and force redirect on logout

### DIFF
--- a/client/src/hooks/use-auth.ts
+++ b/client/src/hooks/use-auth.ts
@@ -110,9 +110,15 @@ export function useAuth() {
   });
 
   const logout = async (): Promise<void> => {
-    await supabase.auth.signOut();
-    queryClient.setQueryData(["/api/auth/user"], null);
-    queryClient.clear();
+    try {
+      await supabase.auth.signOut();
+    } catch {
+      // Ignore signOut errors — always clear local state
+    } finally {
+      queryClient.setQueryData(["/api/auth/user"], null);
+      queryClient.clear();
+      window.location.href = "/";
+    }
   };
 
   return {


### PR DESCRIPTION
## Problem
Users get stuck in a logged-in state with no valid user data and cannot log out.

## Fix
- Wrapped signOut() in try/catch
- State cleanup always runs in finally block
- Force redirect to / after clearing state