### PR TITLE
fix: project creation feedback + missing parentType cases

### DIFF
--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -210,6 +210,8 @@ export function Header() {
     onSuccess: (project) => {
       queryClient.invalidateQueries({ queryKey: ["/api/projects"] });
       setSelectedProject({ id: project.id, name: project.name });
+      setProjectName(project.name);
+      toast({ title: "Project created", description: project.name });
     },
     onError: (err: Error) => {
       toast({ title: "Error", description: `Failed to create project: ${err.message}`, variant: "destructive" });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -246,10 +246,13 @@ export class DatabaseStorage implements IStorage {
         return project?.id;
       }
       case "brief":
+      case "brief_section":
         return this.getProjectIdForBrief(parentId);
       case "discovery":
+      case "discovery_category":
         return this.getProjectIdForDiscoveryCategory(parentId);
       case "deliverable":
+      case "deliverable_asset":
         return this.getProjectIdForDeliverable(parentId);
       default:
         return undefined;


### PR DESCRIPTION
## Summary
- **Success toast on project creation**: Users now see a confirmation toast when a project is created, plus the project name updates immediately in the header. Previously there was zero UI feedback — projects were being created in the database but users thought nothing happened.
- **Missing parentType cases in `getProjectIdForParent`**: Added `brief_section`, `discovery_category`, and `deliverable_asset` fall-through cases so ownership checks work for section/category/asset-level chat messages.

## Test plan
- [ ] Create a new project — verify a success toast appears and the project name updates in the header
- [ ] Open a brief section chat and send a message — verify no 404/ownership error
- [ ] Open a discovery category chat and send a message — verify no 404/ownership error
- [ ] Open a deliverable asset chat and send a message — verify no 404/ownership error

🤖 Generated with [Claude Code](https://claude.com/claude-code)