### PR TITLE
feat: soft-delete (archive) projects

### DIFF
--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -1,7 +1,18 @@
 import { useEffect, useState } from "react";
 import { Link, useLocation } from "wouter";
-import { ChevronDown, FolderPlus, LogOut, Settings, User, Shield, MessageSquare, Sun, Moon, Palette } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { ChevronDown, FolderPlus, LogOut, Settings, User, Shield, MessageSquare, Sun, Moon, Palette, Trash2 } from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { ApiProject } from "@/lib/api";
 import { getSelectedProject, setSelectedProject, subscribeToSelectedProject } from "@/lib/projectStore";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useAuth } from "@/hooks/use-auth";
@@ -115,6 +126,8 @@ export function Header() {
     ? [user.firstName, user.lastName].filter(Boolean).join(" ") || user.email || "User"
     : "User";
 
+  const [projectToDelete, setProjectToDelete] = useState<ApiProject | null>(null);
+
   const { data: projects = [] } = useQuery({
     queryKey: ["/api/projects"],
     queryFn: () => api.projects.list(),
@@ -218,6 +231,25 @@ export function Header() {
     },
   });
 
+  const deleteProjectMutation = useMutation({
+    mutationFn: (id: string) => api.projects.delete(id),
+    onSuccess: (_data, deletedId) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/projects"] });
+      const current = getSelectedProject();
+      if (current.id === deletedId) {
+        const remaining = projects.filter((p) => p.id !== deletedId);
+        if (remaining.length > 0) {
+          setSelectedProject({ id: remaining[0].id, name: remaining[0].name });
+          setProjectName(remaining[0].name);
+        }
+      }
+      toast({ title: "Project archived", description: "It will be permanently deleted after 30 days." });
+    },
+    onError: (err: Error) => {
+      toast({ title: "Error", description: `Failed to archive project: ${err.message}`, variant: "destructive" });
+    },
+  });
+
   useEffect(() => {
     return subscribeToSelectedProject((p) => setProjectName(p.name));
   }, []);
@@ -269,6 +301,19 @@ export function Header() {
                     active
                   </span>
                 )}
+                <button
+                  type="button"
+                  className="ml-auto p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
+                  data-testid={`button-delete-project-${p.id}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    setProjectToDelete(p);
+                  }}
+                  aria-label={`Archive ${p.name}`}
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
               </DropdownMenuItem>
             ))}
 
@@ -400,6 +445,30 @@ export function Header() {
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+      <AlertDialog open={!!projectToDelete} onOpenChange={(open) => { if (!open) setProjectToDelete(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Archive project?</AlertDialogTitle>
+            <AlertDialogDescription>
+              <strong>{projectToDelete?.name}</strong> will be archived and permanently deleted after 30 days.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              onClick={() => {
+                if (projectToDelete) {
+                  deleteProjectMutation.mutate(projectToDelete.id);
+                  setProjectToDelete(null);
+                }
+              }}
+            >
+              Archive
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </header>
   );
 }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -12,6 +12,7 @@ export type ApiProject = {
     undone: string[];
     nextSteps: string[];
   };
+  archivedAt: string | null;
   createdAt: string;
 };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import express, { type Request, Response, NextFunction } from "express";
 import cors from "cors";
 import { registerRoutes } from "./routes";
 import { createServer } from "http";
+import { storage } from "./storage";
 
 const app = express();
 const httpServer = createServer(app);
@@ -70,8 +71,22 @@ app.use((req, res, next) => {
   next();
 });
 
+async function runCleanup(): Promise<void> {
+  try {
+    const count = await storage.permanentlyDeleteExpiredProjects();
+    if (count > 0) {
+      log(`Permanently deleted ${count} expired archived project(s)`, "cleanup");
+    }
+  } catch (err) {
+    log(`Cleanup failed: ${(err as Error).message}`, "cleanup");
+  }
+}
+
 (async () => {
   await registerRoutes(httpServer, app);
+
+  runCleanup();
+  setInterval(runCleanup, 24 * 60 * 60 * 1000);
 
   app.use((err: Error & { status?: number; statusCode?: number }, _req: Request, res: Response, next: NextFunction) => {
     const status = err.status || err.statusCode || 500;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,4 @@
-import { eq, asc, and } from "drizzle-orm";
+import { eq, asc, and, isNull, lt } from "drizzle-orm";
 import { db } from "./db";
 import {
   projects, briefSections, discoveryCategories, deliverables, bucketItems, chatMessages, coreQueries,
@@ -17,6 +17,8 @@ export interface IStorage {
   createProject(data: InsertProject): Promise<Project>;
   updateProject(id: string, data: Partial<InsertProject>): Promise<Project | undefined>;
   deleteProject(id: string): Promise<void>;
+  restoreProject(id: string): Promise<Project | undefined>;
+  permanentlyDeleteExpiredProjects(): Promise<number>;
   listAllProjects(): Promise<Project[]>;
 
   listBriefSections(projectId: string): Promise<BriefSection[]>;
@@ -63,13 +65,13 @@ export interface IStorage {
 export class DatabaseStorage implements IStorage {
   async listProjects(userId?: string): Promise<Project[]> {
     if (userId) {
-      return db.select().from(projects).where(eq(projects.userId, userId)).orderBy(asc(projects.createdAt));
+      return db.select().from(projects).where(and(eq(projects.userId, userId), isNull(projects.archivedAt))).orderBy(asc(projects.createdAt));
     }
-    return db.select().from(projects).orderBy(asc(projects.createdAt));
+    return db.select().from(projects).where(isNull(projects.archivedAt)).orderBy(asc(projects.createdAt));
   }
 
   async listAllProjects(): Promise<Project[]> {
-    return db.select().from(projects).orderBy(asc(projects.createdAt));
+    return db.select().from(projects).where(isNull(projects.archivedAt)).orderBy(asc(projects.createdAt));
   }
 
   async getProject(id: string): Promise<Project | undefined> {
@@ -88,7 +90,18 @@ export class DatabaseStorage implements IStorage {
   }
 
   async deleteProject(id: string): Promise<void> {
-    await db.delete(projects).where(eq(projects.id, id));
+    await db.update(projects).set({ archivedAt: new Date() }).where(eq(projects.id, id));
+  }
+
+  async restoreProject(id: string): Promise<Project | undefined> {
+    const [row] = await db.update(projects).set({ archivedAt: null }).where(eq(projects.id, id)).returning();
+    return row;
+  }
+
+  async permanentlyDeleteExpiredProjects(): Promise<number> {
+    const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const deleted = await db.delete(projects).where(lt(projects.archivedAt, cutoff)).returning();
+    return deleted.length;
   }
 
   async listBriefSections(projectId: string): Promise<BriefSection[]> {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -17,6 +17,7 @@ export const projects = pgTable("projects", {
     undone: string[];
     nextSteps: string[];
   }>().notNull().default({ status: "", done: [], undone: [], nextSteps: [] }),
+  archivedAt: timestamp("archived_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
@@ -84,7 +85,7 @@ export const coreQueries = pgTable("core_queries", {
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
-export const insertProjectSchema = createInsertSchema(projects).omit({ id: true, createdAt: true });
+export const insertProjectSchema = createInsertSchema(projects).omit({ id: true, createdAt: true, archivedAt: true });
 export const insertBriefSectionSchema = createInsertSchema(briefSections).omit({ id: true });
 export const insertDiscoveryCategorySchema = createInsertSchema(discoveryCategories).omit({ id: true });
 export const insertDeliverableSchema = createInsertSchema(deliverables).omit({ id: true });


### PR DESCRIPTION
## Summary
- **Soft-delete instead of hard-delete**: `deleteProject()` now sets `archivedAt` timestamp instead of removing the row. Archived projects are filtered from all list queries but remain accessible for ownership checks.
- **30-day cleanup job**: A background job runs on server startup and every 24 hours, permanently deleting projects archived more than 30 days ago. FK cascades clean up child records.
- **Delete UI in Header dropdown**: Each project in the switcher now has a trash icon. Clicking it opens an AlertDialog confirmation. On confirm, the project is archived and the user sees a toast. If the active project is archived, the app switches to the next available project.

## Changes
| File | Change |
|------|--------|
| `shared/schema.ts` | Added nullable `archivedAt` column, excluded from insert schema |
| `server/storage.ts` | Soft-delete logic, `restoreProject()`, `permanentlyDeleteExpiredProjects()` |
| `server/index.ts` | Cleanup job on startup + 24h interval |
| `client/src/components/layout/Header.tsx` | Trash icon, AlertDialog confirmation, delete mutation |
| `client/src/lib/api.ts` | Added `archivedAt` to `ApiProject` type |

## Migration
Run `npx drizzle-kit push` after deploy to add the `archived_at` column.

## Test plan
- [ ] Open project dropdown, verify trash icon appears on each project
- [ ] Click trash icon, verify confirmation dialog appears
- [ ] Confirm archive, verify project disappears from list and toast is shown
- [ ] Archive the active project, verify app switches to another project
- [ ] Verify `npm run check` and `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)