### PR TITLE
feat: replace browser window.prompt with native dialog component

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,6 +23,7 @@ import CoreQsPage from "@/pages/CoreQsPage";
 import StyleGuidePage from "@/pages/StyleGuidePage";
 import NotFound from "@/pages/not-found";
 import ResetPasswordPage from "@/pages/ResetPasswordPage";
+import { PromptDialogProvider } from "@/components/shared/PromptDialogProvider";
 import { Loader2 } from "lucide-react";
 
 function AuthenticatedRouter() {
@@ -86,8 +87,10 @@ function App() {
     <ThemeProvider>
       <QueryClientProvider client={queryClient}>
         <TooltipProvider>
-          <Toaster />
-          <AppContent />
+          <PromptDialogProvider>
+            <Toaster />
+            <AppContent />
+          </PromptDialogProvider>
         </TooltipProvider>
       </QueryClientProvider>
     </ThemeProvider>

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -20,6 +20,7 @@ import { useTheme } from "next-themes";
 import { api } from "@/lib/api";
 import { queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import { usePromptDialog } from "@/components/shared/PromptDialogProvider";
 
 function generateTemplateFromSnippet(projectName: string, snippet: string) {
   const cleaned = snippet.replace(/\s+/g, " ").trim();
@@ -118,6 +119,7 @@ export function Header() {
   const { user, logout } = useAuth();
   const { theme, setTheme } = useTheme();
   const { toast } = useToast();
+  const { prompt } = usePromptDialog();
 
   const userInitials = user
     ? ((user.firstName?.[0] || "") + (user.lastName?.[0] || "")).toUpperCase() || (user.email?.[0] || "?").toUpperCase()
@@ -322,13 +324,16 @@ export function Header() {
             <DropdownMenuItem
               data-testid="menu-project-new"
               onSelect={() => {
-                const name = window.prompt("Project name", "New Project");
-                if (!name) return;
-
-                const summary = window.prompt("Project summary (one paragraph)", "");
-                if (summary === null) return;
-
-                createProjectMutation.mutate({ name, summary });
+                prompt({
+                  title: "New Project",
+                  fields: [
+                    { name: "name", label: "Project name", defaultValue: "New Project" },
+                    { name: "summary", label: "Summary", type: "textarea", placeholder: "One paragraph summary..." },
+                  ],
+                }).then((result) => {
+                  if (!result) return;
+                  createProjectMutation.mutate({ name: result.name, summary: result.summary });
+                });
               }}
             >
               <FolderPlus className="w-4 h-4 mr-2" />

--- a/client/src/components/shared/PromptDialogProvider.tsx
+++ b/client/src/components/shared/PromptDialogProvider.tsx
@@ -1,0 +1,166 @@
+import { createContext, useContext, useState, useRef, useEffect, useCallback, type ReactNode } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+type FieldType = "text" | "textarea" | "url";
+
+interface PromptField {
+  name: string;
+  label: string;
+  placeholder?: string;
+  defaultValue?: string;
+  type?: FieldType;
+}
+
+interface PromptConfig {
+  title: string;
+  description?: string;
+  submitLabel?: string;
+  fields: PromptField[];
+}
+
+type PromptResult = Record<string, string> | null;
+
+interface PromptDialogContextValue {
+  prompt: (config: PromptConfig) => Promise<PromptResult>;
+}
+
+const PromptDialogContext = createContext<PromptDialogContextValue | null>(null);
+
+export function usePromptDialog(): PromptDialogContextValue {
+  const ctx = useContext(PromptDialogContext);
+  if (!ctx) {
+    throw new Error("usePromptDialog must be used within <PromptDialogProvider>");
+  }
+  return ctx;
+}
+
+export function PromptDialogProvider({ children }: { children: ReactNode }): ReactNode {
+  const [open, setOpen] = useState(false);
+  const [config, setConfig] = useState<PromptConfig | null>(null);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const resolverRef = useRef<((result: PromptResult) => void) | null>(null);
+  const firstInputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+
+  const prompt = useCallback((cfg: PromptConfig): Promise<PromptResult> => {
+    const initial: Record<string, string> = {};
+    for (const field of cfg.fields) {
+      initial[field.name] = field.defaultValue ?? "";
+    }
+    setConfig(cfg);
+    setValues(initial);
+    setOpen(true);
+
+    return new Promise<PromptResult>((resolve) => {
+      resolverRef.current = resolve;
+    });
+  }, []);
+
+  const handleSubmit = useCallback((): void => {
+    setOpen(false);
+    resolverRef.current?.(values);
+    resolverRef.current = null;
+  }, [values]);
+
+  const handleCancel = useCallback((): void => {
+    setOpen(false);
+    resolverRef.current?.(null);
+    resolverRef.current = null;
+  }, []);
+
+  const handleFieldChange = useCallback((name: string, value: string): void => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+  }, []);
+
+  useEffect(() => {
+    if (open && firstInputRef.current) {
+      firstInputRef.current.focus();
+      if ("select" in firstInputRef.current) {
+        firstInputRef.current.select();
+      }
+    }
+  }, [open]);
+
+  return (
+    <PromptDialogContext.Provider value={{ prompt }}>
+      {children}
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) handleCancel();
+        }}
+      >
+        <DialogContent className="max-w-md">
+          {config && (
+            <>
+              <DialogHeader>
+                <DialogTitle>{config.title}</DialogTitle>
+                {config.description && (
+                  <DialogDescription>{config.description}</DialogDescription>
+                )}
+              </DialogHeader>
+
+              <form
+                className="flex flex-col gap-4"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  handleSubmit();
+                }}
+              >
+                {config.fields.map((field, idx) => {
+                  const fieldType = field.type ?? "text";
+
+                  return (
+                    <div key={field.name} className="flex flex-col gap-1.5">
+                      <Label htmlFor={`prompt-field-${field.name}`}>
+                        {field.label}
+                      </Label>
+                      {fieldType === "textarea" ? (
+                        <Textarea
+                          id={`prompt-field-${field.name}`}
+                          ref={idx === 0 ? (el) => { firstInputRef.current = el; } : undefined}
+                          value={values[field.name] ?? ""}
+                          placeholder={field.placeholder}
+                          onChange={(e) => handleFieldChange(field.name, e.target.value)}
+                          rows={3}
+                        />
+                      ) : (
+                        <Input
+                          id={`prompt-field-${field.name}`}
+                          ref={idx === 0 ? (el) => { firstInputRef.current = el; } : undefined}
+                          type={fieldType === "url" ? "url" : "text"}
+                          value={values[field.name] ?? ""}
+                          placeholder={field.placeholder}
+                          onChange={(e) => handleFieldChange(field.name, e.target.value)}
+                        />
+                      )}
+                    </div>
+                  );
+                })}
+
+                <DialogFooter>
+                  <Button type="button" variant="outline" onClick={handleCancel}>
+                    Cancel
+                  </Button>
+                  <Button type="submit">
+                    {config.submitLabel ?? "OK"}
+                  </Button>
+                </DialogFooter>
+              </form>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </PromptDialogContext.Provider>
+  );
+}

--- a/client/src/pages/BriefPage.tsx
+++ b/client/src/pages/BriefPage.tsx
@@ -22,6 +22,7 @@ import { getSelectedProject, subscribeToSelectedProject } from "@/lib/projectSto
 import { Message, Section } from "@/lib/types";
 import { ChevronRight, Target, Flag, Users, AlertTriangle, Circle, ChevronDown, StickyNote, Upload, Link2, RefreshCw, Trash2, FileText as FileTextIcon } from "lucide-react";
 import { cn, getProgressPercent } from "@/lib/utils";
+import { usePromptDialog } from "@/components/shared/PromptDialogProvider";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -114,6 +115,7 @@ function BriefSectionChat({ sectionId, sectionName }: { sectionId: string; secti
 
 export default function BriefPage() {
   const queryClient = useQueryClient();
+  const { prompt } = usePromptDialog();
   const [activeProject, setActiveProject] = useState(getSelectedProject());
 
   const { data: briefSections } = useQuery({
@@ -328,39 +330,46 @@ export default function BriefPage() {
     });
   };
 
-  const handleAddSection = () => {
-    const name = window.prompt("New brief section", "New section");
-    if (!name) return;
+  const handleAddSection = (): void => {
+    prompt({
+      title: "New Brief Section",
+      fields: [
+        { name: "name", label: "Section name", defaultValue: "New section" },
+      ],
+    }).then((result) => {
+      if (!result) return;
+      const name = result.name;
 
-    const tempId = `section-${Date.now()}`;
-    const newSection: LocalSection = {
-      id: tempId,
-      genericName: name,
-      subtitle: "(draft)",
-      completeness: 0,
-      totalItems: 0,
-      completedItems: 0,
-      content: "",
-      items: [],
-      isOpen: true,
-    };
+      const tempId = `section-${Date.now()}`;
+      const newSection: LocalSection = {
+        id: tempId,
+        genericName: name,
+        subtitle: "(draft)",
+        completeness: 0,
+        totalItems: 0,
+        completedItems: 0,
+        content: "",
+        items: [],
+        isOpen: true,
+      };
 
-    setSections((prev) => [newSection, ...prev]);
+      setSections((prev) => [newSection, ...prev]);
 
-    api.brief.create(activeProject.id, {
-      genericName: name,
-      subtitle: "(draft)",
-      completeness: 0,
-      totalItems: 0,
-      completedItems: 0,
-      content: "",
-    }).then((created) => {
-      setSections(prev => prev.map(s => s.id === tempId ? { ...s, id: created.id } : s));
-    }).catch(() => {});
+      api.brief.create(activeProject.id, {
+        genericName: name,
+        subtitle: "(draft)",
+        completeness: 0,
+        totalItems: 0,
+        completedItems: 0,
+        content: "",
+      }).then((created) => {
+        setSections(prev => prev.map(s => s.id === tempId ? { ...s, id: created.id } : s));
+      }).catch(() => {});
 
-    setTimeout(() => {
-      sectionRefs.current[tempId]?.scrollIntoView({ behavior: "smooth", block: "start" });
-    }, 50);
+      setTimeout(() => {
+        sectionRefs.current[tempId]?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }, 50);
+    });
   };
 
   const summaryStatus = projectData?.dashboardStatus?.status || "Seeded from the project summary. Next: make the brief explicit.";
@@ -477,16 +486,21 @@ export default function BriefPage() {
                                             className="h-7 w-7 inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
                                             onClick={(e) => {
                                                 e.stopPropagation();
-                                                const title = window.prompt(`New note in "${section.genericName}"`, "Quick note");
-                                                if (!title) return;
-                                                const content = window.prompt("Note text", "");
-
-                                                addSectionItem(section.id, {
-                                                    id: `${Date.now()}`,
-                                                    type: 'note',
-                                                    title,
-                                                    preview: (content || "").slice(0, 80) || "(empty)",
-                                                    date: new Date().toLocaleDateString([], { month: 'short', day: 'numeric' })
+                                                prompt({
+                                                    title: `New Note in "${section.genericName}"`,
+                                                    fields: [
+                                                        { name: "title", label: "Title", defaultValue: "Quick note" },
+                                                        { name: "content", label: "Content", type: "textarea" },
+                                                    ],
+                                                }).then((result) => {
+                                                    if (!result) return;
+                                                    addSectionItem(section.id, {
+                                                        id: `${Date.now()}`,
+                                                        type: 'note',
+                                                        title: result.title,
+                                                        preview: (result.content || "").slice(0, 80) || "(empty)",
+                                                        date: new Date().toLocaleDateString([], { month: 'short', day: 'numeric' })
+                                                    });
                                                 });
                                             }}
                                             aria-label="Make a note"
@@ -537,17 +551,24 @@ export default function BriefPage() {
                                             className="h-7 w-7 inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
                                             onClick={(e) => {
                                                 e.stopPropagation();
-                                                const url = window.prompt("Paste a link (URL)", "https://");
-                                                if (!url) return;
-                                                const title = window.prompt("Link name", url) || url;
-
-                                                addSectionItem(section.id, {
-                                                    id: `${Date.now()}`,
-                                                    type: 'link',
-                                                    title,
-                                                    preview: url,
-                                                    date: new Date().toLocaleDateString([], { month: 'short', day: 'numeric' }),
-                                                    url
+                                                prompt({
+                                                    title: "Add Link",
+                                                    fields: [
+                                                        { name: "url", label: "URL", type: "url", placeholder: "https://" },
+                                                        { name: "title", label: "Link name" },
+                                                    ],
+                                                }).then((result) => {
+                                                    if (!result) return;
+                                                    const url = result.url;
+                                                    const title = result.title || url;
+                                                    addSectionItem(section.id, {
+                                                        id: `${Date.now()}`,
+                                                        type: 'link',
+                                                        title,
+                                                        preview: url,
+                                                        date: new Date().toLocaleDateString([], { month: 'short', day: 'numeric' }),
+                                                        url
+                                                    });
                                                 });
                                             }}
                                             aria-label="Link a file"

--- a/client/src/pages/DeliverablesPage.tsx
+++ b/client/src/pages/DeliverablesPage.tsx
@@ -22,6 +22,7 @@ import { getSelectedProject, subscribeToSelectedProject } from "@/lib/projectSto
 import { Message, Deliverable } from "@/lib/types";
 import { FileText, Download, Share2, CheckSquare, Edit3, ChevronRight, StickyNote, Upload, Link2, RefreshCw, Trash2, FileText as FileTextIcon } from "lucide-react";
 import { cn, getProgressPercent } from "@/lib/utils";
+import { usePromptDialog } from "@/components/shared/PromptDialogProvider";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -101,6 +102,7 @@ type LocalDeliverable = Deliverable & { isOpen?: boolean };
 
 export default function DeliverablesPage() {
   const queryClient = useQueryClient();
+  const { prompt } = usePromptDialog();
   const [activeProject, setActiveProject] = useState(getSelectedProject());
 
   const { data: apiDeliverables } = useQuery({
@@ -337,39 +339,46 @@ export default function DeliverablesPage() {
             size="sm"
             className="w-full justify-start px-3 mt-2 text-xs text-muted-foreground hover:text-primary"
             onClick={() => {
-              const name = window.prompt("New deliverable", "New deliverable");
-              if (!name) return;
+              prompt({
+                title: "New Deliverable",
+                fields: [
+                  { name: "name", label: "Deliverable name", defaultValue: "New deliverable" },
+                ],
+              }).then((result) => {
+                if (!result) return;
+                const name = result.name;
 
-              const tempId = `deliv-${Date.now()}`;
-              const newDeliverable: LocalDeliverable = {
-                id: tempId,
-                title: name,
-                subtitle: "(draft)",
-                completeness: 0,
-                status: "draft",
-                lastEdited: "Just now",
-                content: "# " + name + "\n\n(TBD)",
-                items: [],
-                engaged: false,
-                isOpen: true,
-              };
+                const tempId = `deliv-${Date.now()}`;
+                const newDeliverable: LocalDeliverable = {
+                  id: tempId,
+                  title: name,
+                  subtitle: "(draft)",
+                  completeness: 0,
+                  status: "draft",
+                  lastEdited: "Just now",
+                  content: "# " + name + "\n\n(TBD)",
+                  items: [],
+                  engaged: false,
+                  isOpen: true,
+                };
 
-              setDeliverables((prev) => [newDeliverable, ...prev]);
+                setDeliverables((prev) => [newDeliverable, ...prev]);
 
-              api.deliverables.create(activeProject.id, {
-                title: name,
-                subtitle: "(draft)",
-                completeness: 0,
-                status: "draft",
-                content: "# " + name + "\n\n(TBD)",
-                engaged: false,
-              }).then((created) => {
-                setDeliverables(prev => prev.map(d => d.id === tempId ? { ...d, id: created.id } : d));
-              }).catch(() => {});
+                api.deliverables.create(activeProject.id, {
+                  title: name,
+                  subtitle: "(draft)",
+                  completeness: 0,
+                  status: "draft",
+                  content: "# " + name + "\n\n(TBD)",
+                  engaged: false,
+                }).then((created) => {
+                  setDeliverables(prev => prev.map(d => d.id === tempId ? { ...d, id: created.id } : d));
+                }).catch(() => {});
 
-              setTimeout(() => {
-                deliverableRefs.current[tempId]?.scrollIntoView({ behavior: "smooth", block: "start" });
-              }, 50);
+                setTimeout(() => {
+                  deliverableRefs.current[tempId]?.scrollIntoView({ behavior: "smooth", block: "start" });
+                }, 50);
+              });
             }}
           >
             + New Deliverable
@@ -461,16 +470,21 @@ export default function DeliverablesPage() {
                                             className="h-7 w-7 inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
                                             onClick={(e) => {
                                                 e.stopPropagation();
-                                                const title = window.prompt(`New note in "${doc.title}"`, "Quick note");
-                                                if (!title) return;
-                                                const content = window.prompt("Note text", "");
-
-                                                addDeliverableItem(doc.id, {
-                                                    id: `${Date.now()}`,
-                                                    type: 'note',
-                                                    title,
-                                                    preview: (content || "").slice(0, 80) || "(empty)",
-                                                    date: new Date().toLocaleDateString([], { month: 'short', day: 'numeric' })
+                                                prompt({
+                                                    title: `New Note in "${doc.title}"`,
+                                                    fields: [
+                                                        { name: "title", label: "Title", defaultValue: "Quick note" },
+                                                        { name: "content", label: "Content", type: "textarea" },
+                                                    ],
+                                                }).then((result) => {
+                                                    if (!result) return;
+                                                    addDeliverableItem(doc.id, {
+                                                        id: `${Date.now()}`,
+                                                        type: 'note',
+                                                        title: result.title,
+                                                        preview: (result.content || "").slice(0, 80) || "(empty)",
+                                                        date: new Date().toLocaleDateString([], { month: 'short', day: 'numeric' })
+                                                    });
                                                 });
                                             }}
                                             aria-label="Make a note"
@@ -523,17 +537,24 @@ export default function DeliverablesPage() {
                                             className="h-7 w-7 inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
                                             onClick={(e) => {
                                                 e.stopPropagation();
-                                                const url = window.prompt("Paste a link (URL)", "https://");
-                                                if (!url) return;
-                                                const title = window.prompt("Link name", url) || url;
-
-                                                addDeliverableItem(doc.id, {
-                                                    id: `${Date.now()}`,
-                                                    type: 'link',
-                                                    title,
-                                                    preview: url,
-                                                    date: new Date().toLocaleDateString([], { month: 'short', day: 'numeric' }),
-                                                    url
+                                                prompt({
+                                                    title: "Add Link",
+                                                    fields: [
+                                                        { name: "url", label: "URL", type: "url", placeholder: "https://" },
+                                                        { name: "title", label: "Link name" },
+                                                    ],
+                                                }).then((result) => {
+                                                    if (!result) return;
+                                                    const url = result.url;
+                                                    const title = result.title || url;
+                                                    addDeliverableItem(doc.id, {
+                                                        id: `${Date.now()}`,
+                                                        type: 'link',
+                                                        title,
+                                                        preview: url,
+                                                        date: new Date().toLocaleDateString([], { month: 'short', day: 'numeric' }),
+                                                        url
+                                                    });
                                                 });
                                             }}
                                             aria-label="Link a file"

--- a/client/src/pages/DiscoveryPage.tsx
+++ b/client/src/pages/DiscoveryPage.tsx
@@ -22,6 +22,7 @@ import { getSelectedProject, subscribeToSelectedProject } from "@/lib/projectSto
 import { Message, Category } from "@/lib/types";
 import { FileText, Link as LinkIcon, MessageSquare, StickyNote, FolderOpen, Folder, Plus, ChevronRight, Upload, Link2, RefreshCw, Trash2 } from "lucide-react";
 import { cn, getProgressPercent } from "@/lib/utils";
+import { usePromptDialog } from "@/components/shared/PromptDialogProvider";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -100,6 +101,7 @@ type LocalCategory = Category;
 
 export default function DiscoveryPage() {
   const queryClient = useQueryClient();
+  const { prompt } = usePromptDialog();
   const [activeProject, setActiveProject] = useState(getSelectedProject());
   const [categories, setCategories] = useState<LocalCategory[]>([]);
   const [messages, setMessages] = useState<Message[]>([]);
@@ -298,27 +300,34 @@ export default function DiscoveryPage() {
             size="sm"
             className="w-full justify-start px-3 mt-2 text-xs text-muted-foreground hover:text-primary"
             onClick={() => {
-              const name = window.prompt("New category", "New category");
-              if (!name) return;
+              prompt({
+                title: "New Category",
+                fields: [
+                  { name: "name", label: "Category name", defaultValue: "New category" },
+                ],
+              }).then((result) => {
+                if (!result) return;
+                const name = result.name;
 
-              const id = `category-${Date.now()}`;
-              setCategories((prev) => [
-                {
-                  id,
-                  name,
-                  isOpen: true,
-                  items: [],
-                },
-                ...prev,
-              ]);
+                const id = `category-${Date.now()}`;
+                setCategories((prev) => [
+                  {
+                    id,
+                    name,
+                    isOpen: true,
+                    items: [],
+                  },
+                  ...prev,
+                ]);
 
-              api.discovery.create(activeProject.id, { name }).then(created => {
-                setCategories(prev => prev.map(b => b.id === id ? { ...b, id: created.id, name: created.name } : b));
-              }).catch(() => {});
+                api.discovery.create(activeProject.id, { name }).then(created => {
+                  setCategories(prev => prev.map(b => b.id === id ? { ...b, id: created.id, name: created.name } : b));
+                }).catch(() => {});
 
-              setTimeout(() => {
-                categoryRefs.current[id]?.scrollIntoView({ behavior: "smooth", block: "start" });
-              }, 50);
+                setTimeout(() => {
+                  categoryRefs.current[id]?.scrollIntoView({ behavior: "smooth", block: "start" });
+                }, 50);
+              });
             }}
           >
             + New Category
@@ -410,16 +419,21 @@ export default function DiscoveryPage() {
                                             className="h-7 w-7 inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
                                             onClick={(e) => {
                                                 e.stopPropagation();
-                                                const title = window.prompt(`New note in "${category.name}"`, "Quick note");
-                                                if (!title) return;
-                                                const content = window.prompt("Note text", "");
-
-                                                addCategoryItem(category.id, {
-                                                    id: `${Date.now()}`,
-                                                    type: 'note',
-                                                    title,
-                                                    preview: (content || "").slice(0, 80) || "(empty)",
-                                                    date: new Date().toLocaleDateString([], { month: 'short', day: 'numeric' })
+                                                prompt({
+                                                    title: `New Note in "${category.name}"`,
+                                                    fields: [
+                                                        { name: "title", label: "Title", defaultValue: "Quick note" },
+                                                        { name: "content", label: "Content", type: "textarea" },
+                                                    ],
+                                                }).then((result) => {
+                                                    if (!result) return;
+                                                    addCategoryItem(category.id, {
+                                                        id: `${Date.now()}`,
+                                                        type: 'note',
+                                                        title: result.title,
+                                                        preview: (result.content || "").slice(0, 80) || "(empty)",
+                                                        date: new Date().toLocaleDateString([], { month: 'short', day: 'numeric' })
+                                                    });
                                                 });
                                             }}
                                             aria-label="Make a note"
@@ -472,17 +486,24 @@ export default function DiscoveryPage() {
                                             className="h-7 w-7 inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
                                             onClick={(e) => {
                                                 e.stopPropagation();
-                                                const url = window.prompt("Paste a link (URL)", "https://");
-                                                if (!url) return;
-                                                const title = window.prompt("Link name", url) || url;
-
-                                                addCategoryItem(category.id, {
-                                                    id: `${Date.now()}`,
-                                                    type: 'link',
-                                                    title,
-                                                    preview: url,
-                                                    date: new Date().toLocaleDateString([], { month: 'short', day: 'numeric' }),
-                                                    url
+                                                prompt({
+                                                    title: "Add Link",
+                                                    fields: [
+                                                        { name: "url", label: "URL", type: "url", placeholder: "https://" },
+                                                        { name: "title", label: "Link name" },
+                                                    ],
+                                                }).then((result) => {
+                                                    if (!result) return;
+                                                    const url = result.url;
+                                                    const title = result.title || url;
+                                                    addCategoryItem(category.id, {
+                                                        id: `${Date.now()}`,
+                                                        type: 'link',
+                                                        title,
+                                                        preview: url,
+                                                        date: new Date().toLocaleDateString([], { month: 'short', day: 'numeric' }),
+                                                        url
+                                                    });
                                                 });
                                             }}
                                             aria-label="Link a file"


### PR DESCRIPTION
## Summary
- Adds `PromptDialogProvider` with an async `prompt()` hook that renders a shadcn `Dialog` instead of browser-native `window.prompt()` calls
- Replaces all 12 `window.prompt` call sites across Header, Discovery, Brief, and Deliverables pages
- Supports multi-field dialogs (text, textarea, url), auto-focus, Enter-to-submit, and Escape-to-cancel

## Test plan
- [ ] Click "New Project" in header dropdown — native dialog appears with name + summary fields
- [ ] Add category/note/link in Discovery page — all use native dialogs
- [ ] Add section/note/link in Brief page — all use native dialogs
- [ ] Add deliverable/note/link in Deliverables page — all use native dialogs
- [ ] Verify Enter submits, Escape cancels, auto-focus works
- [ ] `npm run check` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)