### PR TITLE
feat: add Supabase auth users page in admin panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,6 @@ SUPABASE_URL=https://your-project.supabase.co
 CORS_ORIGIN=https://your-vercel-app.vercel.app
 PORT=3001
 
-# === Admin ===
-ADMIN_EMAILS=admin@example.com
-
 # === AI Provider ===
 AI_PROVIDER=anthropic
 ANTHROPIC_API_KEY=sk-ant-...

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,7 @@ import AdminPage from "@/pages/AdminPage";
 import CoreQsPage from "@/pages/CoreQsPage";
 import StyleGuidePage from "@/pages/StyleGuidePage";
 import TrashPage from "@/pages/TrashPage";
+import AuthUsersPage from "@/pages/AuthUsersPage";
 import NotFound from "@/pages/not-found";
 import ResetPasswordPage from "@/pages/ResetPasswordPage";
 import { PromptDialogProvider } from "@/components/shared/PromptDialogProvider";
@@ -48,6 +49,7 @@ function AuthenticatedRouter() {
       <Route path="/account/security" component={SecurityPage} />
 
       <Route path="/admin" component={AdminPage} />
+      <Route path="/admin/auth-users" component={AuthUsersPage} />
       <Route path="/admin/coreqs" component={CoreQsPage} />
       <Route path="/admin/style-guide" component={StyleGuidePage} />
 

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -62,8 +62,15 @@ export default function AdminPage() {
             <div className="h-6 w-px bg-border" />
             <h1 className="font-bold text-lg" data-testid="text-admin-title">Admin Dashboard</h1>
           </div>
-          <div className="text-sm text-muted-foreground" data-testid="text-admin-user">
-            Signed in as {user?.firstName || user?.email || "Admin"}
+          <div className="flex items-center gap-3">
+            <Link href="/admin/auth-users">
+              <Button variant="outline" size="sm" className="gap-2" data-testid="button-auth-users">
+                <Users className="w-4 h-4" /> Auth Users
+              </Button>
+            </Link>
+            <div className="text-sm text-muted-foreground" data-testid="text-admin-user">
+              Signed in as {user?.firstName || user?.email || "Admin"}
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/pages/AuthUsersPage.tsx
+++ b/client/src/pages/AuthUsersPage.tsx
@@ -1,0 +1,177 @@
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Users, ArrowLeft, Mail, Calendar, ShieldCheck, Smartphone } from "lucide-react";
+import { Link } from "wouter";
+import { fetchJson } from "@/lib/api";
+
+type AuthUser = {
+  id: string;
+  email: string;
+  phone: string;
+  created_at: string;
+  last_sign_in_at: string | null;
+  email_confirmed_at: string | null;
+  phone_confirmed_at: string | null;
+  user_metadata: {
+    first_name?: string;
+    last_name?: string;
+    full_name?: string;
+    avatar_url?: string;
+    picture?: string;
+  };
+  app_metadata: {
+    provider?: string;
+    providers?: string[];
+  };
+  identities?: Array<{
+    provider: string;
+    identity_data?: {
+      email?: string;
+      full_name?: string;
+      avatar_url?: string;
+    };
+  }>;
+};
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "Never";
+  return new Date(dateStr).toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function getUserName(u: AuthUser): string {
+  const meta = u.user_metadata;
+  if (meta.full_name) return meta.full_name;
+  if (meta.first_name || meta.last_name) {
+    return [meta.first_name, meta.last_name].filter(Boolean).join(" ");
+  }
+  return u.email || u.phone || "Unknown";
+}
+
+function getAvatar(u: AuthUser): string | undefined {
+  return u.user_metadata.avatar_url || u.user_metadata.picture || undefined;
+}
+
+export default function AuthUsersPage() {
+  const { data: authUsers = [], isLoading } = useQuery<AuthUser[]>({
+    queryKey: ["/api/admin/auth-users"],
+    queryFn: () => fetchJson("/api/admin/auth-users"),
+  });
+
+  return (
+    <div className="min-h-screen bg-background" data-testid="auth-users-page">
+      <div className="border-b bg-background">
+        <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <Link href="/admin">
+              <Button variant="ghost" size="sm" className="gap-2" data-testid="button-auth-users-back">
+                <ArrowLeft className="w-4 h-4" /> Admin Dashboard
+              </Button>
+            </Link>
+            <div className="h-6 w-px bg-border" />
+            <h1 className="font-bold text-lg" data-testid="text-auth-users-title">Supabase Auth Users</h1>
+          </div>
+          <div className="flex items-center gap-2">
+            <Users className="w-4 h-4 text-muted-foreground" />
+            <span className="text-sm text-muted-foreground" data-testid="text-auth-users-count">
+              {authUsers.length} user{authUsers.length === 1 ? "" : "s"}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
+        <Card data-testid="card-auth-users">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldCheck className="w-5 h-5" />
+              Registered Accounts
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="py-8 text-center text-muted-foreground text-sm">Loading...</div>
+            ) : (
+              <div className="divide-y">
+                {authUsers.map((u) => {
+                  const name = getUserName(u);
+                  const avatar = getAvatar(u);
+                  const providers = u.app_metadata.providers || (u.app_metadata.provider ? [u.app_metadata.provider] : []);
+
+                  return (
+                    <div key={u.id} className="flex items-center justify-between py-4" data-testid={`row-auth-user-${u.id}`}>
+                      <div className="flex items-center gap-3">
+                        {avatar ? (
+                          <img src={avatar} alt="" className="w-10 h-10 rounded-full" />
+                        ) : (
+                          <div className="w-10 h-10 rounded-full bg-muted flex items-center justify-center text-sm font-medium">
+                            {(name[0] || "?").toUpperCase()}
+                          </div>
+                        )}
+                        <div>
+                          <div className="text-sm font-medium" data-testid={`text-auth-user-name-${u.id}`}>
+                            {name}
+                          </div>
+                          <div className="flex items-center gap-3 mt-0.5">
+                            {u.email && (
+                              <div className="flex items-center gap-1 text-xs text-muted-foreground" data-testid={`text-auth-user-email-${u.id}`}>
+                                <Mail className="w-3 h-3" />
+                                {u.email}
+                              </div>
+                            )}
+                            {u.phone && (
+                              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                                <Smartphone className="w-3 h-3" />
+                                {u.phone}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="flex items-center gap-3">
+                        <div className="flex items-center gap-1.5">
+                          {providers.map((p) => (
+                            <Badge key={p} variant="outline" className="text-[10px]" data-testid={`badge-provider-${u.id}-${p}`}>
+                              {p}
+                            </Badge>
+                          ))}
+                          {u.email_confirmed_at && (
+                            <Badge variant="default" className="text-[10px]" data-testid={`badge-email-confirmed-${u.id}`}>
+                              Email verified
+                            </Badge>
+                          )}
+                        </div>
+
+                        <div className="text-right min-w-[140px]">
+                          <div className="flex items-center gap-1 text-xs text-muted-foreground" data-testid={`text-auth-user-created-${u.id}`}>
+                            <Calendar className="w-3 h-3" />
+                            Joined {formatDate(u.created_at)}
+                          </div>
+                          <div className="text-[11px] text-muted-foreground mt-0.5" data-testid={`text-auth-user-last-sign-in-${u.id}`}>
+                            Last sign-in: {formatDate(u.last_sign_in_at)}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+
+                {authUsers.length === 0 && !isLoading && (
+                  <div className="py-8 text-center text-muted-foreground text-sm">No auth users found</div>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/server/auth/storage.ts
+++ b/server/auth/storage.ts
@@ -7,13 +7,6 @@ export interface IAuthStorage {
   upsertUser(user: UpsertUser): Promise<User>;
 }
 
-const ADMIN_EMAILS: ReadonlySet<string> = new Set(
-  (process.env.ADMIN_EMAILS ?? "")
-    .split(",")
-    .map((e) => e.trim().toLowerCase())
-    .filter(Boolean),
-);
-
 class AuthStorage implements IAuthStorage {
   async getUser(id: string): Promise<User | undefined> {
     const [user] = await db.select().from(users).where(eq(users.id, id));
@@ -23,19 +16,17 @@ class AuthStorage implements IAuthStorage {
   async upsertUser(userData: UpsertUser): Promise<User> {
     const [countResult] = await db.select({ count: sql<number>`count(*)` }).from(users);
     const isFirstUser = Number(countResult.count) === 0;
-    const isAllowlistedAdmin = !!(userData.email && ADMIN_EMAILS.has(userData.email.toLowerCase()));
 
     const [user] = await db
       .insert(users)
       .values({
         ...userData,
-        isAdmin: (isFirstUser || isAllowlistedAdmin) ? true : undefined,
+        isAdmin: isFirstUser ? true : undefined,
       })
       .onConflictDoUpdate({
         target: users.id,
         set: {
           ...userData,
-          isAdmin: isAllowlistedAdmin ? true : undefined,
           updatedAt: new Date(),
         },
       })

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -8,6 +8,7 @@ import { db } from "./db";
 import { users, projects } from "@shared/schema";
 import { eq, sql } from "drizzle-orm";
 import { getAIProvider, type AIMessage } from "./ai";
+import { createClient } from "@supabase/supabase-js";
 
 const syncUserSchema = z.object({
   email: z.string().email().nullable(),
@@ -450,6 +451,23 @@ export async function registerRoutes(
     if (!user) return res.status(404).json({ message: "User not found" });
     const [updated] = await db.update(users).set({ isActive: !user.isActive }).where(eq(users.id, targetId)).returning();
     res.json(updated);
+  });
+
+  // === SUPABASE AUTH USERS (admin only) ===
+  app.get("/api/admin/auth-users", isAuthenticated, isAdmin, async (_req, res) => {
+    const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceRoleKey) {
+      return res.status(500).json({ message: "Supabase service role key not configured" });
+    }
+    const supabase = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const { data, error } = await supabase.auth.admin.listUsers({ perPage: 1000 });
+    if (error) {
+      return res.status(500).json({ message: error.message });
+    }
+    res.json(data.users);
   });
 
   // === CORE QUERIES (admin write, all users read) ===


### PR DESCRIPTION
## Summary

- New admin page at `/admin/auth-users` that pulls all registered users from Supabase Auth via the service role API
- Displays name, email, auth provider (Google, email, etc.), email verification status, sign-up date, and last sign-in
- Accessible from an "Auth Users" button on the Admin Dashboard header
- Also removes the `ADMIN_EMAILS` env var approach — admin management is now fully database-driven via the admin panel toggle
- `SUPABASE_SERVICE_ROLE_KEY` has been set in Railway

## Test plan

- [ ] Navigate to `/admin` as an admin user and click "Auth Users"
- [ ] Verify all Supabase-registered accounts appear with correct metadata
- [ ] Verify non-admin users cannot access the page (403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)