### PR TITLE
feat: dynamic context injection for AI prompts

### DIFF
--- a/server/prompts/assembler.ts
+++ b/server/prompts/assembler.ts
@@ -3,18 +3,30 @@ import type { PromptBlockForLocation } from "@shared/schema";
 import { formatForModel } from "./model-formatter";
 import type { AssembledPrompt, PromptCategory } from "./types";
 import { PROMPT_CATEGORIES } from "./types";
-import { computeTokenBudget } from "./token-budget";
+import { computeTokenBudget, estimateTokens, getModelConfig } from "./token-budget";
+import { loadContextForLocation } from "./context-loaders";
+import type { ContextParams } from "./context-loaders";
 
 /**
  * Group blocks by category, maintaining the canonical category order:
  * identity → role → constraints → task → context_template
+ *
+ * Core categories are merged into one entry each. context_template blocks
+ * are kept as individual entries so token-budget truncation can shed them
+ * one at a time.
  */
 function groupByCategory(blocks: PromptBlockForLocation[]): { category: PromptCategory; content: string }[] {
   const grouped: { category: PromptCategory; content: string }[] = [];
 
   for (const category of PROMPT_CATEGORIES) {
     const categoryBlocks = blocks.filter((b) => b.category === category);
-    if (categoryBlocks.length > 0) {
+    if (categoryBlocks.length === 0) continue;
+
+    if (category === "context_template") {
+      for (const block of categoryBlocks) {
+        grouped.push({ category, content: block.content });
+      }
+    } else {
       const combined = categoryBlocks.map((b) => b.content).join("\n\n");
       grouped.push({ category, content: combined });
     }
@@ -24,13 +36,68 @@ function groupByCategory(blocks: PromptBlockForLocation[]): { category: PromptCa
 }
 
 /**
+ * Replace {{variable.name}} patterns in block content with values from context data.
+ * Unresolved variables become empty strings so no template syntax leaks to the AI.
+ */
+const TEMPLATE_VAR_REGEX = /\{\{(\w+(?:\.\w+)*)\}\}/g;
+
+function resolveTemplateVariables(
+  blocks: { category: PromptCategory; content: string }[],
+  contextData: Record<string, string>,
+): { category: PromptCategory; content: string }[] {
+  return blocks.map((block) => ({
+    category: block.category,
+    content: block.content.replace(TEMPLATE_VAR_REGEX, (_match, varName: string) => {
+      return contextData[varName] ?? "";
+    }),
+  }));
+}
+
+/**
+ * Format blocks and enforce token budget. Context_template blocks are shed from
+ * the end when the formatted prompt exceeds maxTokens. Returns the final
+ * formatted string so callers don't need to format again.
+ */
+function formatWithBudget(
+  blocks: { category: PromptCategory; content: string }[],
+  providerName: string,
+  maxTokens: number,
+): string {
+  const formatted = formatForModel(blocks, providerName);
+
+  // No context blocks to shed — return as-is
+  const hasContext = blocks.some((b) => b.category === "context_template");
+  if (!hasContext || estimateTokens(formatted) <= maxTokens) {
+    return formatted;
+  }
+
+  // Over budget — shed context_template blocks from the end
+  const coreBlocks = blocks.filter((b) => b.category !== "context_template");
+  const contextBlocks = blocks.filter((b) => b.category === "context_template");
+
+  const kept = [...contextBlocks];
+  while (kept.length > 0) {
+    kept.pop();
+    const candidatePrompt = formatForModel([...coreBlocks, ...kept], providerName);
+    if (estimateTokens(candidatePrompt) <= maxTokens) {
+      return candidatePrompt;
+    }
+  }
+
+  // Still over budget — return core blocks only
+  return formatForModel(coreBlocks, providerName);
+}
+
+/**
  * Assemble a complete system prompt for a chat location.
  * Falls back to core_queries if no prompt blocks are configured.
+ * When contextParams is provided, loads project data and resolves {{template.variables}}.
  */
 export async function assembleSystemPrompt(
   locationKey: string,
   providerName: string,
   fallbackPrompt?: string,
+  contextParams?: ContextParams,
 ): Promise<AssembledPrompt> {
   const blocks = await storage.getBlocksForLocation(locationKey);
 
@@ -43,8 +110,17 @@ export async function assembleSystemPrompt(
     };
   }
 
-  const categoryBlocks = groupByCategory(blocks);
-  const systemMessage = formatForModel(categoryBlocks, providerName);
+  let categoryBlocks = groupByCategory(blocks);
+
+  // Inject project context into template variables
+  if (contextParams) {
+    const contextData = await loadContextForLocation(contextParams);
+    categoryBlocks = resolveTemplateVariables(categoryBlocks, contextData);
+  }
+
+  // Format and enforce token budget (sheds context_template blocks if over limit)
+  const config = getModelConfig(providerName);
+  const systemMessage = formatWithBudget(categoryBlocks, providerName, config.systemTokenBudget);
 
   return {
     systemMessage,

--- a/server/prompts/context-loaders.ts
+++ b/server/prompts/context-loaders.ts
@@ -1,0 +1,226 @@
+import { storage } from "../storage";
+import type { Project, BriefSection, DiscoveryCategory, Deliverable, BucketItem } from "@shared/schema";
+
+export type ContextData = Record<string, string>;
+export type ContextParams = { parentId: string; parentType: string; projectId: string };
+
+/**
+ * Load project context data for a chat location.
+ * Returns a flat key→value map of template variables (e.g. "project.name" → "Office Relocation").
+ */
+export async function loadContextForLocation(params: ContextParams): Promise<ContextData> {
+  switch (params.parentType) {
+    case "dashboard_page":
+      return loadDashboardPage(params);
+    case "brief_page":
+      return loadBriefPage(params);
+    case "brief_section":
+      return loadBriefSection(params);
+    case "discovery_page":
+      return loadDiscoveryPage(params);
+    case "discovery_category":
+      return loadDiscoveryCategory(params);
+    case "deliverable_page":
+      return loadDeliverablePage(params);
+    case "deliverable_asset":
+      return loadDeliverableAsset(params);
+    default:
+      return {};
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-location loaders
+// ---------------------------------------------------------------------------
+
+async function loadDashboardPage(params: ContextParams): Promise<ContextData> {
+  const [project, sections, categories, deliverables] = await Promise.all([
+    storage.getProject(params.projectId),
+    storage.listBriefSections(params.projectId),
+    storage.listDiscoveryCategories(params.projectId),
+    storage.listDeliverables(params.projectId),
+  ]);
+  if (!project) return {};
+
+  return {
+    "project.name": project.name,
+    "project.summary": project.summary,
+    "project.executiveSummary": project.executiveSummary,
+    "project.dashboardStatus": formatDashboardStatus(project),
+    "brief.sectionsList": formatBriefSectionsList(sections),
+    "discovery.categoriesList": formatCategoriesList(categories),
+    "deliverables.list": formatDeliverablesList(deliverables),
+  };
+}
+
+async function loadBriefPage(params: ContextParams): Promise<ContextData> {
+  const [project, sections] = await Promise.all([
+    storage.getProject(params.projectId),
+    storage.listBriefSections(params.projectId),
+  ]);
+  if (!project) return {};
+
+  return {
+    "project.name": project.name,
+    "brief.sectionsDetail": formatBriefSectionsDetail(sections),
+  };
+}
+
+async function loadBriefSection(params: ContextParams): Promise<ContextData> {
+  const [project, section, allSections, items] = await Promise.all([
+    storage.getProject(params.projectId),
+    storage.getBriefSection(params.parentId),
+    storage.listBriefSections(params.projectId),
+    storage.listBucketItems(params.parentId, "brief"),
+  ]);
+  if (!project || !section) return {};
+
+  const siblingNames = allSections
+    .filter((s) => s.id !== section.id)
+    .map((s) => s.genericName);
+
+  return {
+    "project.name": project.name,
+    "section.name": section.genericName,
+    "section.content": section.content,
+    "section.completeness": `${section.completeness}%`,
+    "section.items": formatBucketItemsList(items),
+    "section.siblingNames": siblingNames.join(", "),
+  };
+}
+
+async function loadDiscoveryPage(params: ContextParams): Promise<ContextData> {
+  const [project, categories] = await Promise.all([
+    storage.getProject(params.projectId),
+    storage.listDiscoveryCategories(params.projectId),
+  ]);
+  if (!project) return {};
+
+  const categoriesWithCounts = await Promise.all(
+    categories.map(async (cat) => {
+      const items = await storage.listBucketItems(cat.id, "discovery");
+      return `- ${cat.name} (${items.length} items)`;
+    }),
+  );
+
+  return {
+    "project.name": project.name,
+    "discovery.categoriesWithCounts": categoriesWithCounts.join("\n"),
+  };
+}
+
+async function loadDiscoveryCategory(params: ContextParams): Promise<ContextData> {
+  const [project, category, allCategories, items] = await Promise.all([
+    storage.getProject(params.projectId),
+    storage.getDiscoveryCategory(params.parentId),
+    storage.listDiscoveryCategories(params.projectId),
+    storage.listBucketItems(params.parentId, "discovery"),
+  ]);
+  if (!project || !category) return {};
+
+  const siblingNames = allCategories
+    .filter((c) => c.id !== category.id)
+    .map((c) => c.name);
+
+  return {
+    "project.name": project.name,
+    "category.name": category.name,
+    "category.items": formatBucketItemsList(items),
+    "category.siblingNames": siblingNames.join(", "),
+  };
+}
+
+async function loadDeliverablePage(params: ContextParams): Promise<ContextData> {
+  const [project, deliverables] = await Promise.all([
+    storage.getProject(params.projectId),
+    storage.listDeliverables(params.projectId),
+  ]);
+  if (!project) return {};
+
+  return {
+    "project.name": project.name,
+    "deliverables.detail": formatDeliverablesDetail(deliverables),
+  };
+}
+
+async function loadDeliverableAsset(params: ContextParams): Promise<ContextData> {
+  const [project, deliverable, allDeliverables, items] = await Promise.all([
+    storage.getProject(params.projectId),
+    storage.getDeliverable(params.parentId),
+    storage.listDeliverables(params.projectId),
+    storage.listBucketItems(params.parentId, "deliverable"),
+  ]);
+  if (!project || !deliverable) return {};
+
+  const siblingTitles = allDeliverables
+    .filter((d) => d.id !== deliverable.id)
+    .map((d) => d.title);
+
+  return {
+    "project.name": project.name,
+    "deliverable.title": deliverable.title,
+    "deliverable.status": deliverable.status,
+    "deliverable.completeness": `${deliverable.completeness}%`,
+    "deliverable.content": deliverable.content,
+    "deliverable.items": formatBucketItemsList(items),
+    "deliverable.siblingTitles": siblingTitles.join(", "),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+function formatDashboardStatus(project: Project): string {
+  const ds = project.dashboardStatus;
+  if (!ds) return "";
+  const parts: string[] = [];
+  if (ds.status) parts.push(`Status: ${ds.status}`);
+  if (ds.done.length > 0) parts.push(`Done: ${ds.done.join("; ")}`);
+  if (ds.undone.length > 0) parts.push(`Remaining: ${ds.undone.join("; ")}`);
+  if (ds.nextSteps.length > 0) parts.push(`Next steps: ${ds.nextSteps.join("; ")}`);
+  return parts.join("\n");
+}
+
+function formatBriefSectionsList(sections: BriefSection[]): string {
+  return sections
+    .map((s) => `- ${s.genericName} (${s.completeness}% complete)`)
+    .join("\n");
+}
+
+function formatBriefSectionsDetail(sections: BriefSection[]): string {
+  return sections
+    .map((s) => {
+      const header = `### ${s.genericName} (${s.completeness}%)`;
+      return s.content ? `${header}\n${s.content}` : header;
+    })
+    .join("\n\n");
+}
+
+function formatCategoriesList(categories: DiscoveryCategory[]): string {
+  return categories.map((c) => `- ${c.name}`).join("\n");
+}
+
+function formatDeliverablesList(deliverables: Deliverable[]): string {
+  return deliverables
+    .map((d) => `- ${d.title} [${d.status}] (${d.completeness}%)`)
+    .join("\n");
+}
+
+function formatDeliverablesDetail(deliverables: Deliverable[]): string {
+  return deliverables
+    .map((d) => {
+      const header = `### ${d.title} [${d.status}] (${d.completeness}%)`;
+      return d.content ? `${header}\n${d.content}` : header;
+    })
+    .join("\n\n");
+}
+
+function formatBucketItemsList(items: BucketItem[]): string {
+  return items
+    .map((item) => {
+      const preview = item.preview ? `: ${item.preview.slice(0, 120)}` : "";
+      return `- [${item.type}] ${item.title}${preview}`;
+    })
+    .join("\n");
+}

--- a/server/prompts/index.ts
+++ b/server/prompts/index.ts
@@ -1,29 +1,41 @@
 import type { AIMessage } from "../ai/types";
 import { assembleSystemPrompt } from "./assembler";
 import { windowConversationHistory } from "./token-budget";
+import type { ContextParams } from "./context-loaders";
 
 export type AssemblePromptOptions = {
   locationKey: string;
   conversationHistory: AIMessage[];
   providerName: string;
   fallbackPrompt?: string;
+  parentId?: string;
+  parentType?: string;
+  projectId?: string;
 };
 
 /**
  * Public API: Assemble a complete prompt for an AI chat interaction.
  *
  * 1. Loads prompt blocks for this location (from prompt_locations)
- * 2. Applies model-specific formatting (XML for Claude, MD for GPT)
- * 3. Falls back to core_queries if no blocks are configured
- * 4. Windows conversation history to fit token budget
- * 5. Returns AIMessage[] ready to send to the provider
+ * 2. Loads project context for this location (when parentId/parentType/projectId provided)
+ * 3. Applies model-specific formatting (XML for Claude, MD for GPT)
+ * 4. Resolves {{template.variables}} in blocks with project data
+ * 5. Falls back to core_queries if no blocks are configured
+ * 6. Windows conversation history to fit token budget
+ * 7. Returns AIMessage[] ready to send to the provider
  */
 export async function assemblePrompt(
   options: AssemblePromptOptions,
 ): Promise<AIMessage[]> {
-  const { locationKey, conversationHistory, providerName, fallbackPrompt } = options;
+  const { locationKey, conversationHistory, providerName, fallbackPrompt, parentId, parentType, projectId } = options;
 
-  const assembled = await assembleSystemPrompt(locationKey, providerName, fallbackPrompt);
+  // Build context params when all three fields are present
+  const contextParams: ContextParams | undefined =
+    parentId && parentType && projectId
+      ? { parentId, parentType, projectId }
+      : undefined;
+
+  const assembled = await assembleSystemPrompt(locationKey, providerName, fallbackPrompt, contextParams);
 
   // Window conversation history to fit token budget
   const windowedHistory = windowConversationHistory(conversationHistory, providerName);
@@ -44,3 +56,4 @@ export { estimateTokens, windowConversationHistory } from "./token-budget";
 export { formatForModel } from "./model-formatter";
 export type { AssembledPrompt, TokenBudget, ModelConfig, PromptCategory } from "./types";
 export { PROMPT_CATEGORIES, MODEL_CONFIGS } from "./types";
+export type { ContextData, ContextParams } from "./context-loaders";

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -360,6 +360,9 @@ export async function registerRoutes(
       conversationHistory,
       providerName: provider.getProviderName(),
       fallbackPrompt,
+      parentId,
+      parentType,
+      projectId,
     });
 
     // Set up SSE


### PR DESCRIPTION
## Summary
- Created `server/prompts/context-loaders.ts` with 7 per-location loaders that fetch real project data (sections, categories, deliverables, bucket items) from the database
- Extended the assembler pipeline to resolve `{{template.variables}}` in prompt blocks with actual project content at runtime
- Added token-budget enforcement that sheds `context_template` blocks granularly when the system prompt exceeds 8K tokens
- Passed `parentId`, `parentType`, and `projectId` from the chat route into the assembler (backward compatible — all optional)

## Test plan
- [ ] `npm run check` — zero TypeScript errors
- [ ] `npm run build` — full production build succeeds
- [ ] Create a `context_template` prompt block with `{{project.name}}` and assign to a location — verify the AI references the actual project name
- [ ] Chat on each of the 7 locations (`dashboard_page`, `brief_page`, `brief_section`, `discovery_page`, `discovery_category`, `deliverable_page`, `deliverable_asset`) with template variables — verify correct data injection
- [ ] Chat on a location with no prompt blocks — verify fallback to `core_queries` still works (no regression)
- [ ] Chat on a location with non-template blocks only — verify they pass through unchanged
- [ ] Verify no `{{}}` syntax leaks into AI-visible prompts (unresolved vars become empty strings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)