### PR TITLE
feat: add admin UX guidance to Prompt Block Editor

### DIFF
--- a/client/src/components/admin/BlockEditorDialog.tsx
+++ b/client/src/components/admin/BlockEditorDialog.tsx
@@ -24,11 +24,11 @@ import { useToast } from "@/hooks/use-toast";
 import { Trash2, History, RotateCcw, ChevronDown, ChevronRight } from "lucide-react";
 
 const CATEGORIES = [
-  { value: "identity", label: "Identity" },
-  { value: "role", label: "Role" },
-  { value: "constraints", label: "Constraints" },
-  { value: "task", label: "Task" },
-  { value: "context_template", label: "Context Template" },
+  { value: "identity", label: "Identity", description: "Who the AI is — persona and name" },
+  { value: "role", label: "Role", description: "What the AI does — expertise and responsibilities" },
+  { value: "constraints", label: "Constraints", description: "Rules to follow — tone, limits, forbidden topics" },
+  { value: "task", label: "Task", description: "The specific job for this chat location" },
+  { value: "context_template", label: "Context Template", description: "Dynamic data injected at runtime via {{variables}}" },
 ];
 
 type BlockEditorDialogProps = {
@@ -51,13 +51,13 @@ export function BlockEditorDialog({ open, onOpenChange, blockId }: BlockEditorDi
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const { data: block } = useQuery({
-    queryKey: ["admin", "prompt-blocks", blockId],
+    queryKey: ["/api/admin/prompt-blocks", blockId],
     queryFn: () => api.promptBlocks.get(blockId!),
     enabled: isEditMode && open,
   });
 
   const { data: versions = [] } = useQuery({
-    queryKey: ["admin", "prompt-blocks", blockId, "versions"],
+    queryKey: ["/api/admin/prompt-blocks", blockId, "versions"],
     queryFn: () => api.promptBlocks.versions(blockId!),
     enabled: isEditMode && open && showVersions,
   });
@@ -86,9 +86,9 @@ export function BlockEditorDialog({ open, onOpenChange, blockId }: BlockEditorDi
   }, [open]);
 
   function invalidateAll(): void {
-    queryClient.invalidateQueries({ queryKey: ["admin", "prompt-blocks"] });
-    queryClient.invalidateQueries({ queryKey: ["admin", "prompt-locations"] });
-    queryClient.invalidateQueries({ queryKey: ["admin", "prompt-preview"] });
+    queryClient.invalidateQueries({ queryKey: ["/api/admin/prompt-blocks"] });
+    queryClient.invalidateQueries({ queryKey: ["/api/admin/prompt-locations"] });
+    queryClient.invalidateQueries({ queryKey: ["/api/admin/prompt-preview"] });
   }
 
   const createMutation = useMutation({
@@ -146,6 +146,11 @@ export function BlockEditorDialog({ open, onOpenChange, blockId }: BlockEditorDi
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{isEditMode ? "Edit Block" : "New Block"}</DialogTitle>
+          <p className="text-xs text-muted-foreground">
+            {isEditMode
+              ? "Changes are versioned automatically. Use the change note to document what you changed and why."
+              : "Create a reusable prompt block. After creating it, assign it to one or more chat locations to shape how the AI responds to users there."}
+          </p>
         </DialogHeader>
 
         <div className="space-y-4 py-2">
@@ -158,6 +163,7 @@ export function BlockEditorDialog({ open, onOpenChange, blockId }: BlockEditorDi
                 onChange={(e) => setName(e.target.value)}
                 placeholder="e.g. Core Identity"
               />
+              <p className="text-[11px] text-muted-foreground">A short, descriptive label visible only to admins.</p>
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="block-category">Category</Label>
@@ -167,8 +173,11 @@ export function BlockEditorDialog({ open, onOpenChange, blockId }: BlockEditorDi
                 </SelectTrigger>
                 <SelectContent>
                   {CATEGORIES.map((c) => (
-                    <SelectItem key={c.value} value={c.value}>
-                      {c.label}
+                    <SelectItem key={c.value} value={c.value} textValue={c.label}>
+                      <div>
+                        <div>{c.label}</div>
+                        <div className="text-xs text-muted-foreground">{c.description}</div>
+                      </div>
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -184,6 +193,7 @@ export function BlockEditorDialog({ open, onOpenChange, blockId }: BlockEditorDi
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Brief description of this block's purpose"
             />
+            <p className="text-[11px] text-muted-foreground">Helps other admins understand this block's intent. Not sent to the AI.</p>
           </div>
 
           <div className="space-y-1.5">
@@ -200,6 +210,9 @@ export function BlockEditorDialog({ open, onOpenChange, blockId }: BlockEditorDi
               placeholder="Enter the prompt block content..."
               className="min-h-[200px] resize-y text-sm font-mono"
             />
+            <p className="text-[11px] text-muted-foreground">
+              This text is sent to the AI as part of its system instructions. Write in second person ("You are...", "Your role is..."). Be specific — vague instructions produce vague responses.
+            </p>
           </div>
 
           {isEditMode && (
@@ -211,6 +224,7 @@ export function BlockEditorDialog({ open, onOpenChange, blockId }: BlockEditorDi
                 onChange={(e) => setChangeNote(e.target.value)}
                 placeholder="What changed and why (optional)"
               />
+              <p className="text-[11px] text-muted-foreground">Saved with the version history so you can track why prompts evolved over time.</p>
             </div>
           )}
 

--- a/client/src/components/admin/BlockLibrary.tsx
+++ b/client/src/components/admin/BlockLibrary.tsx
@@ -11,7 +11,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Plus, Search } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Plus, Search, Info } from "lucide-react";
 
 const CATEGORIES = [
   { value: "all", label: "All Categories" },
@@ -22,12 +28,12 @@ const CATEGORIES = [
   { value: "context_template", label: "Context Template" },
 ];
 
-const CATEGORY_LABELS: Record<string, string> = {
-  identity: "Identity",
-  role: "Role",
-  constraints: "Constraints",
-  task: "Task",
-  context_template: "Context Template",
+const CATEGORY_INFO: Record<string, { label: string; tip: string }> = {
+  identity: { label: "Identity", tip: "Sets who the AI is — its name and persona. Most locations need exactly one." },
+  role: { label: "Role", tip: "Defines the AI's expertise and responsibilities for this context." },
+  constraints: { label: "Constraints", tip: "Rules the AI must follow — tone, length limits, topics to avoid." },
+  task: { label: "Task", tip: "The specific job the AI should do when users chat in this location." },
+  context_template: { label: "Context Template", tip: "Injects live project data at runtime via {{variable}} placeholders." },
 };
 
 type BlockLibraryProps = {
@@ -63,8 +69,13 @@ export function BlockLibrary({ blocks, isLoading, onEditBlock, onCreateBlock }: 
     <div className="h-full flex flex-col">
       <div className="px-4 py-3 border-b space-y-3">
         <div className="flex items-center justify-between">
-          <h2 className="text-sm font-semibold">Block Library</h2>
-          <Button size="sm" className="gap-1.5 h-7 text-xs" onClick={onCreateBlock}>
+          <div>
+            <h2 className="text-sm font-semibold">Block Library</h2>
+            <p className="text-[11px] text-muted-foreground mt-0.5">
+              Reusable building blocks that shape AI behavior. Click any block to edit it.
+            </p>
+          </div>
+          <Button size="sm" className="gap-1.5 h-7 text-xs shrink-0" onClick={onCreateBlock}>
             <Plus className="w-3.5 h-3.5" />
             New Block
           </Button>
@@ -98,15 +109,34 @@ export function BlockLibrary({ blocks, isLoading, onEditBlock, onCreateBlock }: 
         {isLoading ? (
           <div className="text-sm text-muted-foreground text-center py-10">Loading...</div>
         ) : filtered.length === 0 ? (
-          <div className="text-sm text-muted-foreground text-center py-10">
-            {blocks.length === 0 ? "No blocks yet. Create one to get started." : "No blocks match your filters."}
+          <div className="text-sm text-muted-foreground text-center py-10 px-6">
+            {blocks.length === 0 ? (
+              <div className="space-y-2">
+                <p className="font-medium text-foreground">No blocks yet</p>
+                <p className="text-xs">Create your first block to start customizing how AI assistants behave. Start with an Identity block to give the AI a persona, then add Role and Task blocks.</p>
+              </div>
+            ) : (
+              "No blocks match your filters."
+            )}
           </div>
         ) : (
           <div className="py-1">
             {Array.from(grouped.entries()).map(([cat, catBlocks]) => (
               <div key={cat}>
-                <div className="sticky top-0 bg-muted/80 backdrop-blur-sm px-4 py-1.5 text-[11px] font-mono uppercase tracking-wider text-muted-foreground border-b">
-                  {CATEGORY_LABELS[cat] ?? cat}
+                <div className="sticky top-0 bg-muted/80 backdrop-blur-sm px-4 py-1.5 text-[11px] font-mono uppercase tracking-wider text-muted-foreground border-b flex items-center gap-1.5">
+                  {CATEGORY_INFO[cat]?.label ?? cat}
+                  {CATEGORY_INFO[cat]?.tip && (
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Info className="w-3 h-3 text-muted-foreground/60 hover:text-foreground cursor-help" />
+                        </TooltipTrigger>
+                        <TooltipContent side="right" className="max-w-[220px] text-xs">
+                          {CATEGORY_INFO[cat].tip}
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  )}
                 </div>
                 {catBlocks.map((block) => (
                   <button

--- a/client/src/components/admin/LocationConfigurator.tsx
+++ b/client/src/components/admin/LocationConfigurator.tsx
@@ -28,6 +28,12 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { PromptPreview } from "./PromptPreview";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { GripVertical, Plus, X, Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -73,9 +79,16 @@ function SortableBlockRow({
         isDragging && "bg-muted/60 shadow-sm"
       )}
     >
-      <div {...listeners} className="cursor-grab text-muted-foreground hover:text-foreground">
-        <GripVertical className="w-4 h-4" />
-      </div>
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div {...listeners} className="cursor-grab text-muted-foreground hover:text-foreground">
+              <GripVertical className="w-4 h-4" />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="left" className="text-xs">Drag to reorder — blocks higher in the list appear first in the prompt</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium truncate">{block?.name ?? "Unknown Block"}</span>
@@ -84,19 +97,37 @@ function SortableBlockRow({
           </Badge>
         </div>
       </div>
-      <Switch
-        checked={location.isActive}
-        onCheckedChange={(checked) => onToggleActive(location.id, checked)}
-        className="shrink-0"
-      />
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive shrink-0"
-        onClick={() => onRemove(location.id)}
-      >
-        <X className="w-3.5 h-3.5" />
-      </Button>
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div>
+              <Switch
+                checked={location.isActive}
+                onCheckedChange={(checked) => onToggleActive(location.id, checked)}
+                className="shrink-0"
+              />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            {location.isActive ? "Active — included in the AI prompt" : "Inactive — excluded from the AI prompt without removing it"}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive shrink-0"
+              onClick={() => onRemove(location.id)}
+            >
+              <X className="w-3.5 h-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">Remove this block from the location</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </div>
   );
 }
@@ -116,7 +147,7 @@ function LocationTab({
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
 
   const { data: assignments = [], isLoading } = useQuery({
-    queryKey: ["admin", "prompt-locations", locationKey],
+    queryKey: ["/api/admin/prompt-locations", locationKey],
     queryFn: () => api.promptLocations.list(locationKey),
   });
 
@@ -129,8 +160,8 @@ function LocationTab({
   const sortedIds = useMemo(() => assignments.map((a) => a.id), [assignments]);
 
   function invalidateLocation(): void {
-    queryClient.invalidateQueries({ queryKey: ["admin", "prompt-locations", locationKey] });
-    queryClient.invalidateQueries({ queryKey: ["admin", "prompt-preview", locationKey] });
+    queryClient.invalidateQueries({ queryKey: ["/api/admin/prompt-locations", locationKey] });
+    queryClient.invalidateQueries({ queryKey: ["/api/admin/prompt-preview", locationKey] });
   }
 
   const addMutation = useMutation({
@@ -172,13 +203,14 @@ function LocationTab({
 
     const reordered = arrayMove(assignments, oldIndex, newIndex);
     queryClient.setQueryData(
-      ["admin", "prompt-locations", locationKey],
+      ["/api/admin/prompt-locations", locationKey],
       reordered
     );
     api.promptLocations.reorder(locationKey, reordered.map((a) => a.id)).catch(() => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "prompt-locations", locationKey] });
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/prompt-locations", locationKey] });
+      toast({ title: "Error", description: "Failed to reorder. Reverting.", variant: "destructive" });
     });
-    queryClient.invalidateQueries({ queryKey: ["admin", "prompt-preview", locationKey] });
+    queryClient.invalidateQueries({ queryKey: ["/api/admin/prompt-preview", locationKey] });
   }
 
   return (
@@ -219,22 +251,32 @@ function LocationTab({
           </PopoverContent>
         </Popover>
 
-        <Button
-          size="sm"
-          variant="ghost"
-          className="gap-1.5 h-7 text-xs ml-auto"
-          onClick={() => setShowPreview(!showPreview)}
-        >
-          {showPreview ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
-          {showPreview ? "Hide Preview" : "Preview"}
-        </Button>
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="gap-1.5 h-7 text-xs ml-auto"
+                onClick={() => setShowPreview(!showPreview)}
+              >
+                {showPreview ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+                {showPreview ? "Hide Preview" : "Preview"}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs max-w-[220px]">
+              See the fully assembled prompt the AI receives — includes all active blocks with templates resolved
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
 
       {isLoading ? (
         <div className="text-sm text-muted-foreground text-center py-6">Loading...</div>
       ) : assignments.length === 0 ? (
-        <div className="text-sm text-muted-foreground text-center py-6 border rounded-md border-dashed">
-          No blocks assigned. Click "Add Block" to get started.
+        <div className="text-sm text-muted-foreground text-center py-6 px-4 border rounded-md border-dashed space-y-1.5">
+          <p className="font-medium text-foreground">No blocks assigned to this location</p>
+          <p className="text-xs">Click "Add Block" above to assign prompt blocks. The AI will use the combined content of all active blocks here as its system instructions when users chat in this location.</p>
         </div>
       ) : (
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
@@ -270,6 +312,9 @@ export function LocationConfigurator({ locations, allBlocks }: LocationConfigura
     <div className="h-full flex flex-col">
       <div className="px-4 py-3 border-b">
         <h2 className="text-sm font-semibold">Location Configurator</h2>
+        <p className="text-[11px] text-muted-foreground mt-0.5">
+          Each tab is a place in the app where users chat with AI. Assign blocks to control what the AI knows and how it responds.
+        </p>
       </div>
       <div className="flex-1 overflow-hidden">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">

--- a/client/src/pages/CoreQsPage.tsx
+++ b/client/src/pages/CoreQsPage.tsx
@@ -7,10 +7,16 @@ import {
   ResizablePanel,
   ResizableHandle,
 } from "@/components/ui/resizable";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { AdminBanner } from "@/components/admin/AdminBanner";
 import { BlockLibrary } from "@/components/admin/BlockLibrary";
 import { LocationConfigurator } from "@/components/admin/LocationConfigurator";
 import { BlockEditorDialog } from "@/components/admin/BlockEditorDialog";
-import { Blocks } from "lucide-react";
+import { Blocks, HelpCircle, ChevronRight } from "lucide-react";
 
 const LOCATIONS = [
   {
@@ -65,11 +71,13 @@ const LOCATIONS = [
 ];
 
 export default function CoreQsPage(): React.ReactElement {
+  // Permission check handled by AdminRoute in App.tsx
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
+  const [helpOpen, setHelpOpen] = useState(false);
 
   const { data: blocks = [], isLoading } = useQuery({
-    queryKey: ["admin", "prompt-blocks"],
+    queryKey: ["/api/admin/prompt-blocks"],
     queryFn: () => api.promptBlocks.list(),
   });
 
@@ -87,6 +95,8 @@ export default function CoreQsPage(): React.ReactElement {
     <div className="h-screen w-screen bg-background text-foreground font-sans flex flex-col overflow-hidden">
       <Header />
       <div className="flex-1 pt-[60px] flex flex-col overflow-hidden">
+        <AdminBanner />
+
         <div className="px-6 py-4 border-b">
           <div className="flex items-center gap-3">
             <Blocks className="w-5 h-5 text-primary" />
@@ -95,8 +105,72 @@ export default function CoreQsPage(): React.ReactElement {
             </h1>
           </div>
           <p className="text-sm text-muted-foreground mt-1" data-testid="text-coreqs-description">
-            Create reusable prompt blocks and assign them to AI chat locations across the application.
+            Control how AI assistants behave across the app. Create blocks on the left, then assign them to chat locations on the right.
           </p>
+
+          <Collapsible open={helpOpen} onOpenChange={setHelpOpen} className="mt-3">
+            <CollapsibleTrigger className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
+              <ChevronRight className={`w-3.5 h-3.5 transition-transform ${helpOpen ? "rotate-90" : ""}`} />
+              <HelpCircle className="w-3.5 h-3.5" />
+              How does this work?
+            </CollapsibleTrigger>
+            <CollapsibleContent className="mt-3 text-sm text-muted-foreground space-y-4 max-w-3xl">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <h3 className="text-xs font-semibold text-foreground uppercase tracking-wide mb-1">Quick Start</h3>
+                  <ol className="space-y-1 text-xs leading-relaxed list-decimal list-inside">
+                    <li>Create an <strong className="text-foreground">Identity</strong> block (e.g. "You are Agility, a project management AI").</li>
+                    <li>Create a <strong className="text-foreground">Role</strong> block describing the AI's expertise.</li>
+                    <li>Add <strong className="text-foreground">Constraints</strong> for tone, length, and topics to avoid.</li>
+                    <li>Add a <strong className="text-foreground">Task</strong> block for each location's specific job.</li>
+                    <li>Switch to the right panel, pick a location tab, and assign your blocks.</li>
+                    <li>Use <strong className="text-foreground">Preview</strong> to see the final assembled prompt.</li>
+                  </ol>
+                </div>
+                <div>
+                  <h3 className="text-xs font-semibold text-foreground uppercase tracking-wide mb-1">Prompt Categories</h3>
+                  <ul className="space-y-1 text-xs leading-relaxed">
+                    <li><strong className="text-foreground">Identity</strong> — Who the AI is. Sets the persona and name.</li>
+                    <li><strong className="text-foreground">Role</strong> — What the AI does. Describes expertise and responsibilities.</li>
+                    <li><strong className="text-foreground">Constraints</strong> — Rules the AI must follow. Tone, length limits, forbidden topics.</li>
+                    <li><strong className="text-foreground">Task</strong> — The specific job for this location. What output the user expects.</li>
+                    <li><strong className="text-foreground">Context Template</strong> — Dynamic data injected at runtime via {"{{variable}}"} placeholders.</li>
+                  </ul>
+                </div>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <h3 className="text-xs font-semibold text-foreground uppercase tracking-wide mb-1">How Assembly Works</h3>
+                  <p className="text-xs leading-relaxed">
+                    When a user sends a message, the system collects all active blocks assigned to that chat location.
+                    Blocks are assembled in category order (identity → role → constraints → task → context_template),
+                    template variables are resolved from live project data, and the final prompt is sent to the AI.
+                    Use the toggle switch on each block to temporarily disable it without removing the assignment.
+                  </p>
+                </div>
+                <div>
+                  <h3 className="text-xs font-semibold text-foreground uppercase tracking-wide mb-1">Tips for Better AI Responses</h3>
+                  <ul className="space-y-1 text-xs leading-relaxed">
+                    <li>Be <strong className="text-foreground">specific</strong> — "Respond in 2-3 sentences" beats "Keep it short".</li>
+                    <li><strong className="text-foreground">Reuse blocks</strong> across locations — assign the same Identity block everywhere for a consistent persona.</li>
+                    <li>Use <strong className="text-foreground">Preview</strong> after changes to verify the assembled prompt reads naturally.</li>
+                    <li><strong className="text-foreground">Drag to reorder</strong> blocks within a location if you need to change emphasis.</li>
+                  </ul>
+                </div>
+              </div>
+              <div>
+                <h3 className="text-xs font-semibold text-foreground uppercase tracking-wide mb-1">Locations</h3>
+                <p className="text-xs leading-relaxed">
+                  Each tab on the right corresponds to a chat location in the app. <strong className="text-foreground">Page-level</strong> locations
+                  power the main chat on each page (Dashboard, Brief, Discovery, Deliverables).{" "}
+                  <strong className="text-foreground">Section/Category/Asset-level</strong> locations power the
+                  expandable chat inside individual items. You can assign different blocks to each location to tailor
+                  the AI's behavior per context — for example, a Discovery chat might emphasize research skills while a
+                  Deliverables chat focuses on writing and formatting.
+                </p>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
         </div>
 
         <div className="flex-1 overflow-hidden">


### PR DESCRIPTION
## Summary
- Adds tooltips, help text, and instructional guidance to the CoreQs admin page (`/admin/coreqs`)
- Category headers in Block Library now have info tooltips explaining each category's purpose
- Drag handles, toggle switches, remove buttons, and preview buttons all have contextual tooltips
- Block Editor Dialog shows field-level help text (Name, Description, Content, Change Note)
- Page-level help section expanded with Quick Start steps and "Tips for Better AI Responses"
- Richer empty states guide new admins on what to do first

## Test plan
- [ ] Visit `/admin/coreqs` and verify the updated subtitle and help section
- [ ] Expand "How does this work?" and verify Quick Start + Tips sections render in 2-column grid
- [ ] Hover category headers in Block Library to see info tooltips
- [ ] Hover drag handle, toggle switch, remove button, and preview button for tooltips
- [ ] Open New Block dialog and verify field help text appears under each field
- [ ] Open Edit Block dialog and verify contextual subtitle and change note help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)